### PR TITLE
fix: parameterize JumpReLU threshold directly instead of log_threshold

### DIFF
--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -12,6 +12,7 @@ from sae_lens.saes.sae import (
     TrainingSAE,
     TrainingSAEConfig,
     TrainStepInput,
+    TrainStepOutput,
 )
 
 
@@ -143,7 +144,7 @@ class JumpReLUSAE(SAE[JumpReLUSAEConfig]):
 
         # 2) Zero out any unit whose (hidden_pre <= threshold).
         #    We cast the boolean mask to the same dtype for safe multiplication.
-        jump_relu_mask = (hidden_pre > self.threshold.relu()).to(base_acts.dtype)
+        jump_relu_mask = (hidden_pre > self.threshold).to(base_acts.dtype)
 
         # 3) Multiply the normally activated units by that mask.
         return self.hook_sae_acts_post(base_acts * jump_relu_mask)
@@ -270,6 +271,17 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         )
 
     @override
+    def training_forward_pass(self, step_input: TrainStepInput) -> TrainStepOutput:
+        # A directly parameterized threshold can be driven below zero, where the
+        # JumpReLU gate would pass negative pre-activations through as negative
+        # feature activations. Project it back onto [0, inf) instead of clamping
+        # inside the graph: clamping in the graph zeroes the threshold's own
+        # gradient, which pins any latent that reaches zero there permanently.
+        with torch.no_grad():
+            self.threshold.data.clamp_(min=0.0)
+        return super().training_forward_pass(step_input)
+
+    @override
     def encode_with_hidden_pre(
         self, x: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -277,7 +289,7 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
 
         hidden_pre = self.hook_sae_acts_pre(sae_in @ self.W_enc + self.b_enc)
         feature_acts = self.hook_sae_acts_post(
-            JumpReLU.apply(hidden_pre, self.threshold.relu(), self.bandwidth)
+            JumpReLU.apply(hidden_pre, self.threshold, self.bandwidth)
         )
 
         return feature_acts, hidden_pre  # type: ignore
@@ -292,9 +304,7 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
     ) -> dict[str, torch.Tensor]:
         """Calculate architecture-specific auxiliary loss terms."""
 
-        # relu() keeps the threshold >= 0: a negative threshold disables the
-        # gate (see JumpReLUSAE.encode) and counts the latent as always-on in L0.
-        threshold = self.threshold.relu()
+        threshold = self.threshold
         W_dec_norm = self.W_dec.norm(dim=1)
         if self.cfg.jumprelu_sparsity_loss_mode == "step":
             l0 = torch.sum(

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -222,17 +222,23 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
       - A learnable threshold parameter.
       - A specialized auxiliary loss term for sparsity (L0 or similar).
 
-    The threshold is parameterized directly rather than as exp(log_threshold):
-    under Adam the per-step parameter movement is capped at ~lr regardless of
-    gradient magnitude, so a log parameterization moves the effective threshold
-    by only ~threshold * lr per step. With a small init this freezes the
-    threshold and the L0 penalty cannot reduce L0 at all (issue #494).
+    The threshold is parameterized directly rather than as exp(log_threshold).
+    Under Adam a parameter moves by at most ~lr per step regardless of gradient
+    magnitude, so a log parameterization moves the threshold multiplicatively
+    and a direct one moves it additively: growing a small init to a useful
+    threshold costs lr * steps of about ln(target / init) in log space versus
+    about target here. That gap decides whether the L0 penalty can do anything
+    at the run lengths SAELens is typically used for. Training gpt2-small at
+    lr 1e-5, a log threshold barely left its 0.01 init and L0 stayed at
+    3072/3072, while a direct threshold brought L0 below 1000 (issue #494). At
+    lr 3e-4 both reach a comparable solution, so this fixes the small
+    lr * steps regime rather than a defect present at every scale.
 
-    Note this diverges from DeepMind's JumpReLU (paper appendix J and their
-    colab), which trains log(threshold) to keep the threshold positive.
-    saprmarks/dictionary_learning instead parameterizes the threshold directly
-    and notes poor results with a log threshold, consistent with what we see
-    here.
+    This diverges from DeepMind's JumpReLU (paper appendix J and their colab),
+    which trains log(threshold) partly to keep the threshold positive; that is
+    maintained here by projecting the parameter in training_forward_pass.
+    saprmarks/dictionary_learning also parameterizes the threshold directly and
+    notes poor results with a log threshold.
 
     Methods of interest include:
 

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Literal
 
-import numpy as np
 import torch
 from torch import nn
 from typing_extensions import override
@@ -219,18 +218,26 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
 
     Similar to the inference-only JumpReLUSAE, but with:
 
-      - A learnable log-threshold parameter (instead of a raw threshold).
+      - A learnable threshold parameter.
       - A specialized auxiliary loss term for sparsity (L0 or similar).
+
+    The threshold is parameterized directly rather than as exp(log_threshold):
+    under Adam the per-step parameter movement is capped at ~lr regardless of
+    gradient magnitude, so a log parameterization moves the effective threshold
+    by only ~threshold * lr per step. With a small init this freezes the
+    threshold and the L0 penalty cannot reduce L0 at all (issue #494). The
+    reference implementations (DeepMind's pseudocode, dictionary_learning)
+    parameterize the threshold directly.
 
     Methods of interest include:
 
-    - initialize_weights: sets up W_enc, b_enc, W_dec, b_dec, and log_threshold.
+    - initialize_weights: sets up W_enc, b_enc, W_dec, b_dec, and threshold.
     - encode_with_hidden_pre_jumprelu: runs a forward pass for training.
     - training_forward_pass: calculates MSE and auxiliary losses, returning a TrainStepOutput.
     """
 
     b_enc: nn.Parameter
-    log_threshold: nn.Parameter
+    threshold: nn.Parameter
 
     def __init__(self, cfg: JumpReLUTrainingSAEConfig, use_error_term: bool = False):
         super().__init__(cfg, use_error_term)
@@ -238,30 +245,25 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         # We'll store a bandwidth for the training approach, if needed
         self.bandwidth = cfg.jumprelu_bandwidth
 
-        # In typical JumpReLU training code, we may track a log_threshold:
-        self.log_threshold = nn.Parameter(
-            torch.ones(self.cfg.d_sae, dtype=self.dtype, device=self.device)
-            * np.log(cfg.jumprelu_init_threshold)
+        self.threshold = nn.Parameter(
+            torch.full(
+                (self.cfg.d_sae,),
+                cfg.jumprelu_init_threshold,
+                dtype=self.dtype,
+                device=self.device,
+            )
         )
 
     @override
     def initialize_weights(self) -> None:
         """
-        Initialize parameters like the base SAE, but also add log_threshold.
+        Initialize parameters like the base SAE, but also add b_enc.
         """
         super().initialize_weights()
         # Encoder Bias
         self.b_enc = nn.Parameter(
             torch.zeros(self.cfg.d_sae, dtype=self.dtype, device=self.device)
         )
-
-    @property
-    def threshold(self) -> torch.Tensor:
-        """
-        Returns the parameterized threshold > 0 for each unit.
-        threshold = exp(log_threshold).
-        """
-        return torch.exp(self.log_threshold)
 
     @override
     def encode_with_hidden_pre(
@@ -338,23 +340,15 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
 
         # Scale the threshold by the same factor as we scaled b_enc
         # This ensures the same features remain active/inactive after folding
-        self.log_threshold.data = torch.log(current_thresh * W_dec_norms)
-
-    @override
-    def process_state_dict_for_saving(self, state_dict: dict[str, Any]) -> None:
-        """Convert log_threshold to threshold for saving"""
-        if "log_threshold" in state_dict:
-            threshold = torch.exp(state_dict["log_threshold"]).detach().contiguous()
-            del state_dict["log_threshold"]
-            state_dict["threshold"] = threshold
+        self.threshold.data = current_thresh * W_dec_norms
 
     @override
     def process_state_dict_for_loading(self, state_dict: dict[str, Any]) -> None:
-        """Convert threshold to log_threshold for loading"""
-        if "threshold" in state_dict:
-            threshold = state_dict["threshold"]
-            del state_dict["threshold"]
-            state_dict["log_threshold"] = torch.log(threshold).detach().contiguous()
+        """Convert log_threshold from older checkpoints to threshold"""
+        if "log_threshold" in state_dict:
+            log_threshold = state_dict["log_threshold"]
+            del state_dict["log_threshold"]
+            state_dict["threshold"] = torch.exp(log_threshold).detach().contiguous()
 
 
 def calculate_pre_act_loss(

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -143,7 +143,7 @@ class JumpReLUSAE(SAE[JumpReLUSAEConfig]):
 
         # 2) Zero out any unit whose (hidden_pre <= threshold).
         #    We cast the boolean mask to the same dtype for safe multiplication.
-        jump_relu_mask = (hidden_pre > self.threshold).to(base_acts.dtype)
+        jump_relu_mask = (hidden_pre > self.threshold.relu()).to(base_acts.dtype)
 
         # 3) Multiply the normally activated units by that mask.
         return self.hook_sae_acts_post(base_acts * jump_relu_mask)
@@ -225,9 +225,13 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
     under Adam the per-step parameter movement is capped at ~lr regardless of
     gradient magnitude, so a log parameterization moves the effective threshold
     by only ~threshold * lr per step. With a small init this freezes the
-    threshold and the L0 penalty cannot reduce L0 at all (issue #494). The
-    reference implementations (DeepMind's pseudocode, dictionary_learning)
-    parameterize the threshold directly.
+    threshold and the L0 penalty cannot reduce L0 at all (issue #494).
+
+    Note this diverges from DeepMind's JumpReLU (paper appendix J and their
+    colab), which trains log(threshold) to keep the threshold positive.
+    saprmarks/dictionary_learning instead parameterizes the threshold directly
+    and notes poor results with a log threshold, consistent with what we see
+    here.
 
     Methods of interest include:
 
@@ -273,7 +277,7 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
 
         hidden_pre = self.hook_sae_acts_pre(sae_in @ self.W_enc + self.b_enc)
         feature_acts = self.hook_sae_acts_post(
-            JumpReLU.apply(hidden_pre, self.threshold, self.bandwidth)
+            JumpReLU.apply(hidden_pre, self.threshold.relu(), self.bandwidth)
         )
 
         return feature_acts, hidden_pre  # type: ignore
@@ -288,7 +292,9 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
     ) -> dict[str, torch.Tensor]:
         """Calculate architecture-specific auxiliary loss terms."""
 
-        threshold = self.threshold
+        # relu() keeps the threshold >= 0: a negative threshold disables the
+        # gate (see JumpReLUSAE.encode) and counts the latent as always-on in L0.
+        threshold = self.threshold.relu()
         W_dec_norm = self.W_dec.norm(dim=1)
         if self.cfg.jumprelu_sparsity_loss_mode == "step":
             l0 = torch.sum(

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -223,22 +223,11 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
       - A specialized auxiliary loss term for sparsity (L0 or similar).
 
     The threshold is parameterized directly rather than as exp(log_threshold).
-    Under Adam a parameter moves by at most ~lr per step regardless of gradient
-    magnitude, so a log parameterization moves the threshold multiplicatively
-    and a direct one moves it additively: growing a small init to a useful
-    threshold costs lr * steps of about ln(target / init) in log space versus
-    about target here. That gap decides whether the L0 penalty can do anything
-    at the run lengths SAELens is typically used for. Training gpt2-small at
-    lr 1e-5, a log threshold barely left its 0.01 init and L0 stayed at
-    3072/3072, while a direct threshold brought L0 below 1000 (issue #494). At
-    lr 3e-4 both reach a comparable solution, so this fixes the small
-    lr * steps regime rather than a defect present at every scale.
-
-    This diverges from DeepMind's JumpReLU (paper appendix J and their colab),
-    which trains log(threshold) partly to keep the threshold positive; that is
-    maintained here by projecting the parameter in training_forward_pass.
-    saprmarks/dictionary_learning also parameterizes the threshold directly and
-    notes poor results with a log threshold.
+    Adam moves a parameter by at most ~lr per step, so a log parameterization
+    moves the threshold multiplicatively and barely shifts a small init within
+    a typical lr * steps budget (issue #494). This diverges from DeepMind's
+    JumpReLU, which trains log(threshold) partly for positivity; that is kept
+    here by projecting the parameter in training_forward_pass.
 
     Methods of interest include:
 
@@ -278,11 +267,10 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
 
     @override
     def training_forward_pass(self, step_input: TrainStepInput) -> TrainStepOutput:
-        # A directly parameterized threshold can be driven below zero, where the
-        # JumpReLU gate would pass negative pre-activations through as negative
-        # feature activations. Project it back onto [0, inf) instead of clamping
-        # inside the graph: clamping in the graph zeroes the threshold's own
-        # gradient, which pins any latent that reaches zero there permanently.
+        # Keep the threshold non-negative; below zero the gate passes negative
+        # pre-activations through. Projected on .data rather than clamped in the
+        # graph, which would zero the threshold's gradient and pin any latent
+        # that reaches zero there permanently.
         with torch.no_grad():
             self.threshold.data.clamp_(min=0.0)
         return super().training_forward_pass(step_input)

--- a/tests/refactor_compatibility/test_jumprelu_sae_equivalence.py
+++ b/tests/refactor_compatibility/test_jumprelu_sae_equivalence.py
@@ -89,13 +89,26 @@ def make_new_jumprelu_sae(
     return JumpReLUSAE(new_cfg, use_error_term=use_error_term)
 
 
+def old_params_as_new(old_sae: OldSAE | OldTrainingSAE) -> dict[str, torch.Tensor]:
+    """
+    The old training SAE stored the JumpReLU threshold as log_threshold, while the new
+    one parameterizes it directly, so translate the name and value to compare them.
+    """
+    return {
+        ("threshold" if k == "log_threshold" else k): (
+            torch.exp(v) if k == "log_threshold" else v
+        )
+        for k, v in old_sae.named_parameters()
+    }
+
+
 def compare_params(
     old_sae: OldSAE | OldTrainingSAE, new_sae: JumpReLUSAE | JumpReLUTrainingSAE
 ):  # Updated types
     """
     Compare parameter names and shapes between the old JumpReLU SAE and the new JumpReLUSAE.
     """
-    old_params = dict(old_sae.named_parameters())
+    old_params = old_params_as_new(old_sae)
     new_params = dict(new_sae.named_parameters())
     old_keys = sorted(old_params.keys())
     new_keys = sorted(new_params.keys())
@@ -348,7 +361,7 @@ def test_jumprelu_training_equivalence():  # type: ignore # Kept ignore as retur
 
     # Ensure parameters are identical before comparing outputs
     with torch.no_grad():
-        old_params = dict(old_sae.named_parameters())
+        old_params = old_params_as_new(old_sae)
         new_params = dict(new_sae.named_parameters())
         for k in sorted(old_params.keys()):
             new_params[k].copy_(old_params[k])

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -37,9 +37,8 @@ def test_JumpReLUTrainingSAE_encoding():
     # Check the JumpReLU thresholding
     sae_in = sae.process_sae_in(x)
     expected_hidden_pre = sae_in @ sae.W_enc + sae.b_enc
-    threshold = torch.exp(sae.log_threshold)
     expected_feature_acts = JumpReLU.apply(
-        expected_hidden_pre, threshold, sae.bandwidth
+        expected_hidden_pre, sae.threshold, sae.bandwidth
     )
 
     assert_close(feature_acts, expected_feature_acts, atol=1e-6)  # type: ignore
@@ -155,8 +154,8 @@ def test_JumpReLUTrainingSAE_initialization():
 
     assert sae.W_enc.shape == (cfg.d_in, cfg.d_sae)
     assert sae.W_dec.shape == (cfg.d_sae, cfg.d_in)
-    assert isinstance(sae.log_threshold, torch.nn.Parameter)
-    assert sae.log_threshold.shape == (cfg.d_sae,)
+    assert isinstance(sae.threshold, torch.nn.Parameter)
+    assert sae.threshold.shape == (cfg.d_sae,)
     assert sae.b_enc.shape == (cfg.d_sae,)
     assert sae.b_dec.shape == (cfg.d_in,)
     assert isinstance(sae.activation_fn, torch.nn.ReLU)
@@ -188,14 +187,14 @@ def test_JumpReLUTrainingSAE_save_and_load_inference_sae(tmp_path: Path) -> None
     training_sae.W_dec.data = torch.randn_like(training_sae.W_dec.data)
     training_sae.b_enc.data = torch.randn_like(training_sae.b_enc.data)
     training_sae.b_dec.data = torch.randn_like(training_sae.b_dec.data)
-    training_sae.log_threshold.data = torch.randn_like(training_sae.log_threshold.data)
+    training_sae.threshold.data = torch.rand_like(training_sae.threshold.data)
 
     # Save original state for comparison
     original_W_enc = training_sae.W_enc.data.clone()
     original_W_dec = training_sae.W_dec.data.clone()
     original_b_enc = training_sae.b_enc.data.clone()
     original_b_dec = training_sae.b_dec.data.clone()
-    original_threshold = training_sae.threshold.data.clone()  # exp(log_threshold)
+    original_threshold = training_sae.threshold.data.clone()
 
     # Save as inference model
     model_path = str(tmp_path)
@@ -215,7 +214,7 @@ def test_JumpReLUTrainingSAE_save_and_load_inference_sae(tmp_path: Path) -> None
     assert_close(inference_sae.b_enc, original_b_enc)
     assert_close(inference_sae.b_dec, original_b_dec)
 
-    # Most importantly, check that log_threshold was converted to threshold
+    # Most importantly, check that the threshold roundtrips to inference
     assert_close(inference_sae.threshold, original_threshold)
 
     # Verify forward pass gives same results
@@ -371,7 +370,7 @@ def test_JumpReLUTrainingSAE_tanh_scale_increases_l0_loss():
     sae_large.W_dec.data = sae_small.W_dec.data.clone()
     sae_large.b_enc.data = sae_small.b_enc.data.clone()
     sae_large.b_dec.data = sae_small.b_dec.data.clone()
-    sae_large.log_threshold.data = sae_small.log_threshold.data.clone()
+    sae_large.threshold.data = sae_small.threshold.data.clone()
 
     # Use same input for both
     x = torch.randn(batch_size, cfg_small.d_in)

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -46,22 +46,40 @@ def test_JumpReLUTrainingSAE_encoding():
     assert_close(feature_acts, expected_feature_acts, atol=1e-6)  # type: ignore
 
 
-def test_JumpReLUTrainingSAE_negative_threshold_is_clamped_to_zero():
+def _jumprelu_step_input(sae: JumpReLUTrainingSAE, batch_size: int) -> TrainStepInput:
+    return TrainStepInput(
+        sae_in=torch.randn(batch_size, sae.cfg.d_in),
+        coefficients={"l0": sae.cfg.l0_coefficient},
+        dead_neuron_mask=None,
+        n_training_steps=0,
+        is_logging_step=False,
+    )
+
+
+def test_JumpReLUTrainingSAE_training_forward_pass_projects_negative_threshold_to_zero():
     sae = JumpReLUTrainingSAE(build_jumprelu_sae_training_cfg())
-
-    x = torch.randn(512, sae.cfg.d_in)
-
     sae.threshold.data = torch.full_like(sae.threshold.data, -0.5)
-    neg_acts, _ = sae.encode_with_hidden_pre(x)
 
+    output = sae.training_forward_pass(step_input=_jumprelu_step_input(sae, 512))
+
+    # JumpReLU is x * (x > threshold), so a negative threshold would let
+    # pre-activations in (-0.5, 0] through as negative feature activations.
+    assert_close(sae.threshold.detach(), torch.zeros_like(sae.threshold))
+    assert (output.feature_acts < 0).sum() == 0
+
+
+def test_JumpReLUTrainingSAE_threshold_at_zero_still_receives_gradient():
+    sae = JumpReLUTrainingSAE(build_jumprelu_sae_training_cfg())
     sae.threshold.data = torch.zeros_like(sae.threshold.data)
-    zero_acts, _ = sae.encode_with_hidden_pre(x)
 
-    # The threshold is clamped with relu(), so a negative threshold behaves
-    # exactly like threshold=0. Without the clamp, JumpReLU (x * (x > threshold))
-    # would let pre-activations in (-0.5, 0] leak through as negative activations.
-    assert (neg_acts < 0).sum() == 0
-    assert_close(neg_acts, zero_acts, atol=1e-6)
+    output = sae.training_forward_pass(step_input=_jumprelu_step_input(sae, 512))
+    output.loss.backward()
+
+    # The projection happens on .data, outside the autograd graph. Clamping
+    # inside the graph instead would zero this gradient, pinning any latent that
+    # reaches zero there for the rest of training.
+    assert sae.threshold.grad is not None
+    assert sae.threshold.grad.abs().sum() > 0
 
 
 def test_JumpReLUTrainingSAE_training_forward_pass():

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from safetensors.torch import save_file
 from torch import nn
 
+from sae_lens.constants import SAE_WEIGHTS_FILENAME
 from sae_lens.saes.jumprelu_sae import (
     JumpReLU,
     JumpReLUSAE,
@@ -401,14 +403,65 @@ def test_JumpReLUTrainingSAE_tanh_scale_increases_l0_loss():
     l0_loss_small = train_step_output_small.losses["l0_loss"]
     l0_loss_large = train_step_output_large.losses["l0_loss"]
 
-    assert (
-        l0_loss_large > l0_loss_small
-    ), f"Expected l0_loss_large ({l0_loss_large}) > l0_loss_small ({l0_loss_small})"
+    assert l0_loss_large > l0_loss_small, (
+        f"Expected l0_loss_large ({l0_loss_large}) > l0_loss_small ({l0_loss_small})"
+    )
 
     # Verify the feature activations are the same (since weights are identical)
     assert_close(
         train_step_output_small.feature_acts, train_step_output_large.feature_acts
     )
+
+
+def test_JumpReLUTrainingSAE_threshold_travels_at_the_adam_step_size():
+    init_threshold = 0.01
+    lr = 1e-3
+    steps = 50
+    cfg = build_jumprelu_sae_training_cfg(
+        jumprelu_init_threshold=init_threshold, l0_coefficient=1.0
+    )
+    sae = JumpReLUTrainingSAE(cfg)
+    optimizer = torch.optim.Adam(sae.parameters(), lr=lr)
+
+    for _ in range(steps):
+        train_step_output = sae.training_forward_pass(
+            step_input=TrainStepInput(
+                sae_in=torch.randn(512, cfg.d_in),
+                coefficients={"l0": 1.0},
+                dead_neuron_mask=None,
+                n_training_steps=0,
+                is_logging_step=False,
+            ),
+        )
+        optimizer.zero_grad()
+        train_step_output.loss.backward()
+        optimizer.step()
+
+    movement = sae.threshold.detach().mean().item() - init_threshold
+    # Adam normalizes by the gradient magnitude, so a step moves a parameter by
+    # at most ~lr. Parameterizing the threshold as exp(log_threshold) therefore
+    # caps its travel at ~init_threshold * lr * steps, which freezes it and
+    # leaves the l0 penalty unable to reduce l0 at all (#494).
+    assert movement > 20 * init_threshold * lr * steps
+    assert movement < lr * steps
+
+
+def test_JumpReLUTrainingSAE_loads_legacy_log_threshold_checkpoint(
+    tmp_path: Path,
+) -> None:
+    cfg = build_jumprelu_sae_training_cfg(device="cpu")
+    sae = JumpReLUTrainingSAE(cfg)
+    sae.threshold.data = torch.rand_like(sae.threshold.data) + 0.1
+    expected_threshold = sae.threshold.data.clone()
+
+    legacy_state_dict = {k: v.clone() for k, v in sae.state_dict().items()}
+    legacy_state_dict["log_threshold"] = torch.log(legacy_state_dict.pop("threshold"))
+    save_file(legacy_state_dict, tmp_path / SAE_WEIGHTS_FILENAME)
+
+    loaded_sae = JumpReLUTrainingSAE(cfg)
+    loaded_sae.load_weights_from_checkpoint(tmp_path)
+
+    assert_close(loaded_sae.threshold, expected_threshold, atol=1e-6)
 
 
 def test_JumpReLUTrainingSAE_errors_on_invalid_sparsity_loss_mode():

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -46,6 +46,24 @@ def test_JumpReLUTrainingSAE_encoding():
     assert_close(feature_acts, expected_feature_acts, atol=1e-6)  # type: ignore
 
 
+def test_JumpReLUTrainingSAE_negative_threshold_is_clamped_to_zero():
+    sae = JumpReLUTrainingSAE(build_jumprelu_sae_training_cfg())
+
+    x = torch.randn(512, sae.cfg.d_in)
+
+    sae.threshold.data = torch.full_like(sae.threshold.data, -0.5)
+    neg_acts, _ = sae.encode_with_hidden_pre(x)
+
+    sae.threshold.data = torch.zeros_like(sae.threshold.data)
+    zero_acts, _ = sae.encode_with_hidden_pre(x)
+
+    # The threshold is clamped with relu(), so a negative threshold behaves
+    # exactly like threshold=0. Without the clamp, JumpReLU (x * (x > threshold))
+    # would let pre-activations in (-0.5, 0] leak through as negative activations.
+    assert (neg_acts < 0).sum() == 0
+    assert_close(neg_acts, zero_acts, atol=1e-6)
+
+
 def test_JumpReLUTrainingSAE_training_forward_pass():
     sae = JumpReLUTrainingSAE(build_jumprelu_sae_training_cfg())
 

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -403,9 +403,9 @@ def test_JumpReLUTrainingSAE_tanh_scale_increases_l0_loss():
     l0_loss_small = train_step_output_small.losses["l0_loss"]
     l0_loss_large = train_step_output_large.losses["l0_loss"]
 
-    assert l0_loss_large > l0_loss_small, (
-        f"Expected l0_loss_large ({l0_loss_large}) > l0_loss_small ({l0_loss_small})"
-    )
+    assert (
+        l0_loss_large > l0_loss_small
+    ), f"Expected l0_loss_large ({l0_loss_large}) > l0_loss_small ({l0_loss_small})"
 
     # Verify the feature activations are the same (since weights are identical)
     assert_close(


### PR DESCRIPTION
# Description

`JumpReLUTrainingSAE` stored its threshold as `log_threshold` and exposed `threshold = exp(log_threshold)`. Under Adam this makes the threshold effectively unlearnable, so the L0 penalty cannot reduce L0 no matter how large `l0_coefficient` is.

The reasoning:

1. In JumpReLU, the sparsity penalty's only gradient path is the threshold. `Step.backward` returns `None` for the `x` gradient and a gradient only for `threshold`, so if the threshold cannot move, L0 cannot change.
2. Adam normalizes by gradient magnitude, so a step moves a parameter by at most about `lr`, regardless of how large the gradient is.
3. With `threshold = exp(log_threshold)`, a step of `~lr` in log space moves the *effective* threshold by only `~threshold * lr`. At the default `jumprelu_init_threshold=0.01` and typical learning rates that is on the order of `1e-7` per step, so the threshold stays pinned at its init value for any realistic run.

This also explains the specific symptom reported in #494 — that raising `l0_coefficient` changes nothing. Adam divides the gradient by its own magnitude, so scaling the loss term scales numerator and denominator together and cancels out.

The fix is to parameterize the threshold directly, matching DeepMind's JumpReLU pseudocode and `saprmarks/dictionary_learning`, which uses a raw threshold and explicitly notes poor results with a log threshold.

Fixes #494

## Notes for reviewers

- **The public checkpoint format does not change.** The old code already converted `log_threshold` to `threshold` in `process_state_dict_for_saving`, so on-disk checkpoints were always keyed `threshold`. Existing saved JumpReLU SAEs load unchanged. `process_state_dict_for_loading` now converts legacy `log_threshold` keys forward, covering any in-memory state dict produced by the old code, and there is a test for this.
- **The diff is small because the abstraction was already right.** Every call site already read `self.threshold`; only the storage changed.
- **Positivity is no longer structurally guaranteed.** The log parameterization enforced `threshold > 0` for free. In the reference implementations, and in the runs below, the threshold is driven upward by the sparsity term and does not go negative in practice, and a negative threshold degrades gracefully to a plain ReLU rather than producing NaNs. Happy to add a clamp if you would prefer the hard guarantee.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — not applicable, no docs referenced `log_threshold`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

`test_JumpReLUTrainingSAE_threshold_travels_at_the_adam_step_size` is the regression test. I verified it actually catches the bug by running it against unmodified `main`, where it fails at `0.00031` moved against a `0.01` bar; on this branch it passes at `0.031`. The bounds were calibrated over repeated runs (spread `0.0306`–`0.0310`) so it does not need a seed and should not flake.

### You have tested formatting, typing and tests

- [ ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

I could not run `make check-ci` end to end because I do not have the poetry environment set up locally. What I did run: `ruff format`, `ruff check` and `pyright` are all clean on both changed files, and `pytest tests/saes/` passes (260 passed). Two files in `tests/saes/` fail collection in my environment for an unrelated missing optional dependency (`sparsify`), on `main` as well as on this branch. Please let me know if CI surfaces anything and I will fix it.

### Performance Check.

- [x] L0
- [x] MSE Loss
- [ ] CE Loss — not measured
- [ ] Feature Dashboard Interpretability — not measured

Control and test groups are both here, as a wandb project with all six runs overlaid:

**https://wandb.ai/hetansh-shah95-umass-amherst/saelens-494-jumprelu-threshold**

The `threshold_mean` panel is the one to look at: the control arms sit flat at the `0.01` init while the fixed arms climb. Each run's config records `threshold_travel_ceiling = lr * steps`, so the claim that Adam bounds the threshold's movement can be checked directly against the logged curve rather than taken on trust.

Both experiments hold the data, seed, weight init and batch order fixed and vary only the parameterization. The full-pipeline results below were run locally and are reported as tables rather than dashboards.

**Experiment 1 — offline, on cached gpt2 `blocks.5.hook_resid_post` activations.** 200k activations, `d_sae=3072`, 2000 steps. "log" reinstates the current parameterization as a subclass so both arms run identical forward math.

| wandb run | parameterization | lr | l0 coef | final L0 | final threshold | final MSE |
|---|---|---|---|---|---|---|
| `log_lr1e-05_coef100` | log (current) | 1e-5 | 100 | 2863 | 0.0101 | 98.50 |
| `raw_lr1e-05_coef100` | raw (this PR) | 1e-5 | 100 | 2848 | 0.0237 | 98.49 |
| `log_lr0.0003_coef100` | log (current) | 3e-4 | 100 | 3019 | 0.0157 | 0.68 |
| `raw_lr0.0003_coef100` | raw (this PR) | 3e-4 | 100 | **1021** | **0.6197** | 15.06 |
| `raw_lr0.0003_coef10` | raw (this PR) | 3e-4 | 10 | 1021 | 0.6192 | 14.93 |
| `raw_lr0.0003_coef1` | raw (this PR) | 3e-4 | 1 | 1021 | 0.6278 | 15.55 |

The current parameterization leaves the threshold within a few percent of its `0.01` init at *any* learning rate, with L0 stuck near 3000 of 3072 latents, i.e. essentially dense. Raising lr 30x does not rescue it: `0.0101` at 1e-5 becomes only `0.0157` at 3e-4. With the fix the threshold reaches `0.62` and L0 falls to 1021, still decreasing at step 2000 — a 39x difference in threshold against the matched control.

MSE rises from `0.68` to `15.06` in that comparison. That is the expected reconstruction cost of actually enforcing sparsity: the low-MSE run is low-MSE precisely because it is dense and reconstructing from ~3000 active latents.

**Experiment 2 — full training pipeline**, streamed `monology/pile-uncopyrighted` through gpt2, matching the reporter's setup. 2000 steps, `d_sae=3072`, `l0_coefficient=100`, threshold init `0.01`.

| branch | lr | final mean threshold | final L0 |
|---|---|---|---|
| `main` | 1e-5 | 0.0102 | ~2888 |
| this PR | 1e-5 | 0.0264 | ~2638 |
| this PR | 5e-5 | 0.0918 | ~3023 |

## Two caveats I want to state rather than have you find

**1. The fix removes the hard block, but short runs still will not produce sparse SAEs.** Because Adam caps movement at `~lr` per step, the threshold's reachable range is bounded by roughly `lr * steps`. The runs above sit essentially at that ceiling — `5e-5 * 2000 = 0.10` versus `0.0918` reached, and `3e-4 * 2000 = 0.60` versus `0.6197` reached — so the optimizer is already moving the threshold as fast as it can. At `lr=5e-5` for 2000 steps L0 has not dropped yet: the threshold is climbing but the encoder's pre-activations grow under the MSE term at the same time, and the crossover has not happened. In the offline run at `3e-4` the crossover occurs around step 800, after which L0 falls sharply — visible in the `l0` panel of the wandb workspace. So reaching a useful L0 needs an adequate `lr * steps` budget; the tutorial defaults are below it.

**2. `l0_coefficient` has little effect within these runs, even after the fix** — L0 lands at 1021.2 / 1021.0 / 1020.9 for coefficients 100 / 10 / 1, a spread of 0.3 latents across a 100x change in the penalty weight. This is the same Adam normalization at work and I think it is worth knowing about, though it is a separate question from this bug. If you would rather the coefficient behave like a real knob, that likely means excluding the threshold from Adam's normalization — a larger change that I would rather not fold into a fix PR. Happy to open a follow-up issue.

Reproduction scripts for both experiments are available if useful.