### PR TITLE
docs: document that l0_coefficient saturates, and warn when it has

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -147,6 +147,32 @@ sparse_autoencoder = LanguageModelSAETrainingRunner(cfg).run()
 
 [JumpReLU SAEs](https://arxiv.org/abs/2407.14435) are a state-of-the-art SAE architecture. To train one, provide a `JumpReLUTrainingSAEConfig` to the `sae` field. JumpReLU SAEs use a sparsity penalty controlled by the `l0_coefficient` parameter. The `JumpReLUTrainingSAEConfig` also has parameters `jumprelu_bandwidth` and `jumprelu_init_threshold` which affect the learning of the thresholds.
 
+<!-- prettier-ignore-start -->
+!!! warning "Choosing `l0_coefficient` in the default `step` mode"
+
+    In the default `jumprelu_sparsity_loss_mode="step"`, the sparsity penalty reaches the
+    model only through the threshold. Adam caps the threshold's movement at roughly `lr`
+    per step regardless of gradient magnitude, so `l0_coefficient` does not set the
+    sparsity level directly — it sets the *direction* of the threshold's update, while
+    `lr * n_steps` sets how far the threshold can travel in total.
+
+    The practical consequence is that `l0_coefficient` **saturates**. Above some value the
+    sparsity gradient already dominates the threshold's update completely, and raising it
+    further changes nothing; in one controlled sweep at 2k steps, L0 moved 10x over
+    `l0_coefficient` in `[1e-3, 1e-1]` and was flat from `1` to `100`. The saturation point
+    is not universal — it depends on activation scale, `jumprelu_bandwidth`, `d_sae`, batch
+    size, and the number of training steps — so it must be found per setup rather than
+    copied. If your sparsity sweep barely moves L0, sweep *downward* by orders of magnitude
+    rather than upward.
+
+    SAELens warns at the end of training when the threshold was still moving at the
+    optimizer's step ceiling, which is the signal that this is happening. See
+    [issue #719](https://github.com/decoderesearch/SAELens/issues/719).
+
+    This applies to `step` mode only. In `tanh` mode the penalty also back-propagates
+    through the encoder and decoder weights, and `l0_coefficient` behaves normally.
+<!-- prettier-ignore-end -->
+
 We support both the original JumpReLU sparsity loss and the more modern [tanh sparsity loss](https://transformer-circuits.pub/2025/january-update/index.html) variant from Anthropic. To use the tanh sparsity loss, set `jumprelu_sparsity_loss_mode="tanh"`. The tanh sparsity loss variant is a bit easier to train, but has more hyperparameters. We recommend using the tanh with `normalize_activations="expected_average_only_in"` to match Anthropic's setup. We also recommend enabling the pre-act loss by setting `pre_act_loss_coefficient` to match Anthropic's setup. An example of this is below:
 
 ```python
@@ -184,7 +210,9 @@ from sae_lens import LanguageModelSAERunnerConfig, LanguageModelSAETrainingRunne
 cfg = LanguageModelSAERunnerConfig( # Full config would be defined here
     # ... other LanguageModelSAERunnerConfig parameters ...
     sae=JumpReLUTrainingSAEConfig(
-        l0_coefficient=5.0, # Sparsity penalty coefficient
+        l0_coefficient=5.0, # Sparsity penalty coefficient; see the warning above -- in
+                            # "step" mode this saturates, so sweep it downward by orders
+                            # of magnitude if L0 barely responds.
         jumprelu_bandwidth=0.01,
         jumprelu_init_threshold=0.01,
         d_in=1024, # must match your hook point

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -14,6 +14,12 @@ from sae_lens.saes.sae import (
     TrainStepInput,
 )
 
+# Adam caps per-step parameter movement at ~lr, so the threshold can travel at most
+# sum(lr) over training. If it travels nearly that far it was moving at the ceiling in
+# one direction the whole run and never reached equilibrium, which is the regime where
+# l0_coefficient stops affecting the final L0 (issue #719).
+RAIL_LIMITED_TRAVEL_FRAC = 0.9
+
 
 def rectangle(x: torch.Tensor) -> torch.Tensor:
     return ((x > -0.5) & (x < 0.5)).to(x)
@@ -187,7 +193,13 @@ class JumpReLUTrainingSAEConfig(TrainingSAEConfig):
         jumprelu_init_threshold: initial threshold for the JumpReLU activation
         jumprelu_bandwidth: bandwidth for the JumpReLU activation
         jumprelu_sparsity_loss_mode: mode for the sparsity loss, either "step" or "tanh". "step" is Google Deepmind's L0 loss, "tanh" is Anthropic's sparsity loss.
-        l0_coefficient: coefficient for the l0 sparsity loss
+        l0_coefficient: coefficient for the l0 sparsity loss. In "step" mode this
+            saturates: the penalty reaches the model only through the threshold, whose
+            movement Adam caps at ~lr per step, so past some value raising it further has
+            no effect and lr * n_steps sets the final L0 instead. The saturation point
+            depends on activation scale, bandwidth, d_sae, batch size and n_steps, so
+            sweep downward by orders of magnitude if L0 does not respond. Behaves normally
+            in "tanh" mode. See https://github.com/decoderesearch/SAELens/issues/719
         l0_warm_up_steps: number of warm-up steps for the l0 sparsity loss
         pre_act_loss_coefficient: coefficient for the pre-activation loss. Set to None to disable. Set to 3e-6 to match Anthropic's setup.
         jumprelu_tanh_scale: scale for the tanh sparsity loss. Only relevant for "tanh" sparsity loss mode.
@@ -349,6 +361,29 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
             log_threshold = state_dict["log_threshold"]
             del state_dict["log_threshold"]
             state_dict["threshold"] = torch.exp(log_threshold).detach().contiguous()
+
+    @override
+    @torch.no_grad()
+    def training_convergence_warning(self, lr_budget: float) -> str | None:
+        if lr_budget <= 0:
+            return None
+        travel = abs(
+            self.threshold.detach().float().mean().item()
+            - self.cfg.jumprelu_init_threshold
+        )
+        if travel < RAIL_LIMITED_TRAVEL_FRAC * lr_budget:
+            return None
+        return (
+            f"The JumpReLU threshold moved {travel:.4g} during training, which is at "
+            f"least {RAIL_LIMITED_TRAVEL_FRAC:.0%} of the {lr_budget:.4g} that Adam "
+            f"permits over this many steps. The threshold was still travelling at the "
+            f"optimizer's step ceiling when training ended, so it never reached the "
+            f"equilibrium where the sparsity and reconstruction gradients balance. In "
+            f"this regime l0_coefficient (={self.cfg.l0_coefficient:g}) has little "
+            f"influence on the final L0, which is set by lr * n_steps instead. Train "
+            f"for more steps or raise the learning rate to put l0_coefficient back in "
+            f"control. See https://github.com/decoderesearch/SAELens/issues/719"
+        )
 
 
 def calculate_pre_act_loss(

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Literal
 
-import numpy as np
 import torch
 from torch import nn
 from typing_extensions import override
@@ -219,18 +218,26 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
 
     Similar to the inference-only JumpReLUSAE, but with:
 
-      - A learnable log-threshold parameter (instead of a raw threshold).
+      - A learnable threshold parameter.
       - A specialized auxiliary loss term for sparsity (L0 or similar).
+
+    The threshold is parameterized directly rather than as exp(log_threshold):
+    under Adam the per-step parameter movement is capped at ~lr regardless of
+    gradient magnitude, so a log parameterization moves the effective threshold
+    by only ~threshold * lr per step. With a small init this freezes the
+    threshold and the L0 penalty cannot reduce L0 at all (issue #494). The
+    reference implementations (DeepMind's pseudocode, dictionary_learning)
+    parameterize the threshold directly.
 
     Methods of interest include:
 
-    - initialize_weights: sets up W_enc, b_enc, W_dec, b_dec, and log_threshold.
+    - initialize_weights: sets up W_enc, b_enc, W_dec, b_dec, and threshold.
     - encode_with_hidden_pre_jumprelu: runs a forward pass for training.
     - training_forward_pass: calculates MSE and auxiliary losses, returning a TrainStepOutput.
     """
 
     b_enc: nn.Parameter
-    log_threshold: nn.Parameter
+    threshold: nn.Parameter
 
     def __init__(self, cfg: JumpReLUTrainingSAEConfig, use_error_term: bool = False):
         super().__init__(cfg, use_error_term)
@@ -238,30 +245,25 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         # We'll store a bandwidth for the training approach, if needed
         self.bandwidth = cfg.jumprelu_bandwidth
 
-        # In typical JumpReLU training code, we may track a log_threshold:
-        self.log_threshold = nn.Parameter(
-            torch.ones(self.cfg.d_sae, dtype=self.dtype, device=self.device)
-            * np.log(cfg.jumprelu_init_threshold)
+        self.threshold = nn.Parameter(
+            torch.full(
+                (self.cfg.d_sae,),
+                cfg.jumprelu_init_threshold,
+                dtype=self.dtype,
+                device=self.device,
+            )
         )
 
     @override
     def initialize_weights(self) -> None:
         """
-        Initialize parameters like the base SAE, but also add log_threshold.
+        Initialize parameters like the base SAE, but also add b_enc.
         """
         super().initialize_weights()
         # Encoder Bias
         self.b_enc = nn.Parameter(
             torch.zeros(self.cfg.d_sae, dtype=self.dtype, device=self.device)
         )
-
-    @property
-    def threshold(self) -> torch.Tensor:
-        """
-        Returns the parameterized threshold > 0 for each unit.
-        threshold = exp(log_threshold).
-        """
-        return torch.exp(self.log_threshold)
 
     @override
     def encode_with_hidden_pre(
@@ -338,23 +340,15 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
 
         # Scale the threshold by the same factor as we scaled b_enc
         # This ensures the same features remain active/inactive after folding
-        self.log_threshold.data = torch.log(current_thresh * W_dec_norms)
-
-    @override
-    def process_state_dict_for_saving(self, state_dict: dict[str, Any]) -> None:
-        """Convert log_threshold to threshold for saving"""
-        if "log_threshold" in state_dict:
-            threshold = torch.exp(state_dict["log_threshold"]).detach().contiguous()
-            del state_dict["log_threshold"]
-            state_dict["threshold"] = threshold
+        self.threshold.data = current_thresh * W_dec_norms
 
     @override
     def process_state_dict_for_loading(self, state_dict: dict[str, Any]) -> None:
-        """Convert threshold to log_threshold for loading"""
-        if "threshold" in state_dict:
-            threshold = state_dict["threshold"]
-            del state_dict["threshold"]
-            state_dict["log_threshold"] = torch.log(threshold).detach().contiguous()
+        """Convert log_threshold from older checkpoints to threshold"""
+        if "log_threshold" in state_dict:
+            log_threshold = state_dict["log_threshold"]
+            del state_dict["log_threshold"]
+            state_dict["threshold"] = torch.exp(log_threshold).detach().contiguous()
 
 
 def calculate_pre_act_loss(

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -1092,6 +1092,18 @@ class TrainingSAE(SAE[T_TRAINING_SAE_CONFIG], ABC):
             "weights/W_dec_norms": W_dec_norm_dist,
         }
 
+    @torch.no_grad()
+    def training_convergence_warning(self, lr_budget: float) -> str | None:
+        """
+        Post-training diagnostic, called once at the end of training.
+
+        `lr_budget` is the sum of the learning rate over every training step, which
+        bounds how far an Adam-optimized parameter can travel. Return a warning
+        message if training appears not to have converged, or None. Architectures
+        with no such diagnostic leave this as-is.
+        """
+        return None
+
     @classmethod
     def get_sae_class_for_architecture(
         cls: type[T_TRAINING_SAE], architecture: str

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -10,7 +10,7 @@ from safetensors.torch import save_file
 from torch.optim import Adam
 from tqdm.auto import tqdm
 
-from sae_lens import __version__
+from sae_lens import __version__, logger
 from sae_lens.config import SAETrainerConfig
 from sae_lens.constants import (
     ACTIVATION_SCALER_CFG_FILENAME,
@@ -102,6 +102,7 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
             sae.cfg.d_sae, device=cfg.device
         )
         self.n_frac_active_samples = 0
+        self.lr_budget = 0.0
 
         self.optimizer = Adam(
             sae.parameters(),
@@ -162,6 +163,9 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
     def fit(self) -> T_TRAINING_SAE:
         self.sae.to(self.cfg.device)
         pbar = tqdm(total=self.cfg.total_training_samples, desc="Training SAE")
+        # The convergence check below measures parameter travel from initialization,
+        # so it is only meaningful for a run that starts from scratch.
+        started_from_scratch = self.n_training_steps == 0
 
         if self.sae.cfg.normalize_activations == "expected_average_only_in":
             self.activation_scaler.estimate_scaling_factor(
@@ -192,6 +196,11 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
                 self.activation_scaler.scaling_factor
             )
             self.activation_scaler.scaling_factor = None
+
+        if started_from_scratch:
+            convergence_warning = self.sae.training_convergence_warning(self.lr_budget)
+            if convergence_warning is not None:
+                logger.warning(convergence_warning)
 
         if self.cfg.save_final_checkpoint:
             self.save_checkpoint(checkpoint_name=f"final_{self.n_training_samples}")
@@ -349,6 +358,10 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
         self.grad_scaler.update()
 
         self.optimizer.zero_grad()
+        # Adam moves a parameter by at most ~lr per step, so the running sum of lr
+        # bounds how far any parameter can have travelled. Used by
+        # TrainingSAE.training_convergence_warning().
+        self.lr_budget += self.optimizer.param_groups[0]["lr"]
         self.lr_scheduler.step()
         for scheduler in self.coefficient_schedulers.values():
             scheduler.step()

--- a/tests/refactor_compatibility/test_jumprelu_sae_equivalence.py
+++ b/tests/refactor_compatibility/test_jumprelu_sae_equivalence.py
@@ -89,13 +89,26 @@ def make_new_jumprelu_sae(
     return JumpReLUSAE(new_cfg, use_error_term=use_error_term)
 
 
+def old_params_as_new(old_sae: OldSAE | OldTrainingSAE) -> dict[str, torch.Tensor]:
+    """
+    The old training SAE stored the JumpReLU threshold as log_threshold, while the new
+    one parameterizes it directly, so translate the name and value to compare them.
+    """
+    return {
+        ("threshold" if k == "log_threshold" else k): (
+            torch.exp(v) if k == "log_threshold" else v
+        )
+        for k, v in old_sae.named_parameters()
+    }
+
+
 def compare_params(
     old_sae: OldSAE | OldTrainingSAE, new_sae: JumpReLUSAE | JumpReLUTrainingSAE
 ):  # Updated types
     """
     Compare parameter names and shapes between the old JumpReLU SAE and the new JumpReLUSAE.
     """
-    old_params = dict(old_sae.named_parameters())
+    old_params = old_params_as_new(old_sae)
     new_params = dict(new_sae.named_parameters())
     old_keys = sorted(old_params.keys())
     new_keys = sorted(new_params.keys())
@@ -348,7 +361,7 @@ def test_jumprelu_training_equivalence():  # type: ignore # Kept ignore as retur
 
     # Ensure parameters are identical before comparing outputs
     with torch.no_grad():
-        old_params = dict(old_sae.named_parameters())
+        old_params = old_params_as_new(old_sae)
         new_params = dict(new_sae.named_parameters())
         for k in sorted(old_params.keys()):
             new_params[k].copy_(old_params[k])

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -37,9 +37,8 @@ def test_JumpReLUTrainingSAE_encoding():
     # Check the JumpReLU thresholding
     sae_in = sae.process_sae_in(x)
     expected_hidden_pre = sae_in @ sae.W_enc + sae.b_enc
-    threshold = torch.exp(sae.log_threshold)
     expected_feature_acts = JumpReLU.apply(
-        expected_hidden_pre, threshold, sae.bandwidth
+        expected_hidden_pre, sae.threshold, sae.bandwidth
     )
 
     assert_close(feature_acts, expected_feature_acts, atol=1e-6)  # type: ignore
@@ -155,8 +154,8 @@ def test_JumpReLUTrainingSAE_initialization():
 
     assert sae.W_enc.shape == (cfg.d_in, cfg.d_sae)
     assert sae.W_dec.shape == (cfg.d_sae, cfg.d_in)
-    assert isinstance(sae.log_threshold, torch.nn.Parameter)
-    assert sae.log_threshold.shape == (cfg.d_sae,)
+    assert isinstance(sae.threshold, torch.nn.Parameter)
+    assert sae.threshold.shape == (cfg.d_sae,)
     assert sae.b_enc.shape == (cfg.d_sae,)
     assert sae.b_dec.shape == (cfg.d_in,)
     assert isinstance(sae.activation_fn, torch.nn.ReLU)
@@ -188,14 +187,14 @@ def test_JumpReLUTrainingSAE_save_and_load_inference_sae(tmp_path: Path) -> None
     training_sae.W_dec.data = torch.randn_like(training_sae.W_dec.data)
     training_sae.b_enc.data = torch.randn_like(training_sae.b_enc.data)
     training_sae.b_dec.data = torch.randn_like(training_sae.b_dec.data)
-    training_sae.log_threshold.data = torch.randn_like(training_sae.log_threshold.data)
+    training_sae.threshold.data = torch.rand_like(training_sae.threshold.data)
 
     # Save original state for comparison
     original_W_enc = training_sae.W_enc.data.clone()
     original_W_dec = training_sae.W_dec.data.clone()
     original_b_enc = training_sae.b_enc.data.clone()
     original_b_dec = training_sae.b_dec.data.clone()
-    original_threshold = training_sae.threshold.data.clone()  # exp(log_threshold)
+    original_threshold = training_sae.threshold.data.clone()
 
     # Save as inference model
     model_path = str(tmp_path)
@@ -215,7 +214,7 @@ def test_JumpReLUTrainingSAE_save_and_load_inference_sae(tmp_path: Path) -> None
     assert_close(inference_sae.b_enc, original_b_enc)
     assert_close(inference_sae.b_dec, original_b_dec)
 
-    # Most importantly, check that log_threshold was converted to threshold
+    # Most importantly, check that the threshold roundtrips to inference
     assert_close(inference_sae.threshold, original_threshold)
 
     # Verify forward pass gives same results
@@ -371,7 +370,7 @@ def test_JumpReLUTrainingSAE_tanh_scale_increases_l0_loss():
     sae_large.W_dec.data = sae_small.W_dec.data.clone()
     sae_large.b_enc.data = sae_small.b_enc.data.clone()
     sae_large.b_dec.data = sae_small.b_dec.data.clone()
-    sae_large.log_threshold.data = sae_small.log_threshold.data.clone()
+    sae_large.threshold.data = sae_small.threshold.data.clone()
 
     # Use same input for both
     x = torch.randn(batch_size, cfg_small.d_in)

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from safetensors.torch import save_file
 from torch import nn
 
+from sae_lens.constants import SAE_WEIGHTS_FILENAME
 from sae_lens.saes.jumprelu_sae import (
     JumpReLU,
     JumpReLUSAE,
@@ -401,14 +403,65 @@ def test_JumpReLUTrainingSAE_tanh_scale_increases_l0_loss():
     l0_loss_small = train_step_output_small.losses["l0_loss"]
     l0_loss_large = train_step_output_large.losses["l0_loss"]
 
-    assert (
-        l0_loss_large > l0_loss_small
-    ), f"Expected l0_loss_large ({l0_loss_large}) > l0_loss_small ({l0_loss_small})"
+    assert l0_loss_large > l0_loss_small, (
+        f"Expected l0_loss_large ({l0_loss_large}) > l0_loss_small ({l0_loss_small})"
+    )
 
     # Verify the feature activations are the same (since weights are identical)
     assert_close(
         train_step_output_small.feature_acts, train_step_output_large.feature_acts
     )
+
+
+def test_JumpReLUTrainingSAE_threshold_travels_at_the_adam_step_size():
+    init_threshold = 0.01
+    lr = 1e-3
+    steps = 50
+    cfg = build_jumprelu_sae_training_cfg(
+        jumprelu_init_threshold=init_threshold, l0_coefficient=1.0
+    )
+    sae = JumpReLUTrainingSAE(cfg)
+    optimizer = torch.optim.Adam(sae.parameters(), lr=lr)
+
+    for _ in range(steps):
+        train_step_output = sae.training_forward_pass(
+            step_input=TrainStepInput(
+                sae_in=torch.randn(512, cfg.d_in),
+                coefficients={"l0": 1.0},
+                dead_neuron_mask=None,
+                n_training_steps=0,
+                is_logging_step=False,
+            ),
+        )
+        optimizer.zero_grad()
+        train_step_output.loss.backward()
+        optimizer.step()
+
+    movement = sae.threshold.detach().mean().item() - init_threshold
+    # Adam normalizes by the gradient magnitude, so a step moves a parameter by
+    # at most ~lr. Parameterizing the threshold as exp(log_threshold) therefore
+    # caps its travel at ~init_threshold * lr * steps, which freezes it and
+    # leaves the l0 penalty unable to reduce l0 at all (#494).
+    assert movement > 20 * init_threshold * lr * steps
+    assert movement < lr * steps
+
+
+def test_JumpReLUTrainingSAE_loads_legacy_log_threshold_checkpoint(
+    tmp_path: Path,
+) -> None:
+    cfg = build_jumprelu_sae_training_cfg(device="cpu")
+    sae = JumpReLUTrainingSAE(cfg)
+    sae.threshold.data = torch.rand_like(sae.threshold.data) + 0.1
+    expected_threshold = sae.threshold.data.clone()
+
+    legacy_state_dict = {k: v.clone() for k, v in sae.state_dict().items()}
+    legacy_state_dict["log_threshold"] = torch.log(legacy_state_dict.pop("threshold"))
+    save_file(legacy_state_dict, tmp_path / SAE_WEIGHTS_FILENAME)
+
+    loaded_sae = JumpReLUTrainingSAE(cfg)
+    loaded_sae.load_weights_from_checkpoint(tmp_path)
+
+    assert_close(loaded_sae.threshold, expected_threshold, atol=1e-6)
 
 
 def test_JumpReLUTrainingSAE_errors_on_invalid_sparsity_loss_mode():

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -485,3 +485,80 @@ def test_JumpReLUTrainingSAE_errors_on_invalid_sparsity_loss_mode():
                 is_logging_step=False,
             ),
         )
+
+
+def test_JumpReLUTrainingSAE_warns_when_threshold_is_rail_limited():
+    init_threshold = 0.01
+    cfg = build_jumprelu_sae_training_cfg(
+        jumprelu_init_threshold=init_threshold, l0_coefficient=1.0
+    )
+    sae = JumpReLUTrainingSAE(cfg)
+    lr_budget = 0.6  # e.g. lr=3e-4 over 2000 steps
+
+    # threshold travelled 95% of what Adam allows: it was still moving at the ceiling
+    sae.threshold.data.fill_(init_threshold + 0.95 * lr_budget)
+
+    warning = sae.training_convergence_warning(lr_budget)
+
+    assert warning is not None
+    assert "l0_coefficient" in warning
+
+
+def test_JumpReLUTrainingSAE_no_convergence_warning_when_threshold_settles():
+    init_threshold = 0.01
+    cfg = build_jumprelu_sae_training_cfg(
+        jumprelu_init_threshold=init_threshold, l0_coefficient=1.0
+    )
+    sae = JumpReLUTrainingSAE(cfg)
+    lr_budget = 0.6
+
+    # threshold used only a third of the available travel, so it reached equilibrium
+    sae.threshold.data.fill_(init_threshold + 0.33 * lr_budget)
+
+    assert sae.training_convergence_warning(lr_budget) is None
+
+
+def test_JumpReLUTrainingSAE_no_convergence_warning_without_lr_budget():
+    sae = JumpReLUTrainingSAE(build_jumprelu_sae_training_cfg())
+
+    assert sae.training_convergence_warning(0.0) is None
+
+
+def test_JumpReLUTrainingSAE_l0_coefficient_saturates_threshold_gradient_direction():
+    """
+    Characterizes the behaviour behind #719: because the threshold receives
+    c * g_l0 + g_mse and Adam fixes the step magnitude at ~lr, the coefficient only
+    controls the *direction* of the update. Once the l0 term dominates, that direction
+    stops changing and the coefficient stops having any effect.
+    """
+    cfg = build_jumprelu_sae_training_cfg(l0_coefficient=1.0)
+    sae = JumpReLUTrainingSAE(cfg)
+    x = torch.randn(512, cfg.d_in, generator=torch.Generator().manual_seed(0))
+
+    def threshold_grad(coefficient: float) -> torch.Tensor:
+        sae.zero_grad()
+        output = sae.training_forward_pass(
+            step_input=TrainStepInput(
+                sae_in=x,
+                coefficients={"l0": coefficient},
+                dead_neuron_mask=None,
+                n_training_steps=0,
+                is_logging_step=False,
+            ),
+        )
+        output.loss.backward()
+        assert sae.threshold.grad is not None
+        grad = sae.threshold.grad.detach().clone()
+        sae.zero_grad()
+        return grad
+
+    saturated = torch.nn.functional.cosine_similarity(
+        threshold_grad(1.0), threshold_grad(100.0), dim=0
+    )
+    assert saturated > 0.999
+
+    # far below saturation the coefficient still changes the update direction
+    unsaturated = torch.nn.functional.cosine_similarity(
+        threshold_grad(0.0), threshold_grad(1.0), dim=0
+    )
+    assert unsaturated < 0.999

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -403,9 +403,9 @@ def test_JumpReLUTrainingSAE_tanh_scale_increases_l0_loss():
     l0_loss_small = train_step_output_small.losses["l0_loss"]
     l0_loss_large = train_step_output_large.losses["l0_loss"]
 
-    assert l0_loss_large > l0_loss_small, (
-        f"Expected l0_loss_large ({l0_loss_large}) > l0_loss_small ({l0_loss_small})"
-    )
+    assert (
+        l0_loss_large > l0_loss_small
+    ), f"Expected l0_loss_large ({l0_loss_large}) > l0_loss_small ({l0_loss_small})"
 
     # Verify the feature activations are the same (since weights are identical)
     assert_close(

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -1,4 +1,6 @@
 import json
+import logging
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Callable
 
@@ -27,6 +29,7 @@ from tests.helpers import (
     TINYSTORIES_MODEL,
     assert_close,
     build_runner_cfg,
+    build_sae_training_cfg,
     load_model_cached,
 )
 
@@ -667,3 +670,85 @@ def test_sae_trainer_fit_logs_train_eval_and_sparsity_metrics_to_wandb(
     assert "model_performance_preservation" in all_keys
     # the feature_sampling_window=2 sparsity reset emits its own log dict
     assert "metrics/mean_log10_feature_sparsity" in all_keys
+
+
+def _constant_data_provider(d_in: int, batch_size: int) -> Iterator[torch.Tensor]:
+    generator = torch.Generator().manual_seed(0)
+    while True:
+        yield torch.randn(batch_size, d_in, generator=generator)
+
+
+def _build_model_free_trainer(
+    sae: TrainingSAE[Any], **cfg_kwargs: Any
+) -> SAETrainer[Any, Any]:
+    cfg = build_runner_cfg(
+        d_in=sae.cfg.d_in,
+        training_tokens=256,
+        train_batch_size_tokens=64,
+        **cfg_kwargs,
+    ).to_sae_trainer_config()
+    return SAETrainer(
+        cfg=cfg,
+        sae=sae,
+        data_provider=_constant_data_provider(
+            sae.cfg.d_in, cfg.train_batch_size_samples
+        ),
+    )
+
+
+def test_sae_trainer_accumulates_lr_budget_matching_lr_times_steps():
+    sae = StandardTrainingSAE(build_sae_training_cfg(d_in=8, d_sae=16))
+    trainer = _build_model_free_trainer(sae, lr=1e-3, lr_scheduler_name="constant")
+
+    assert trainer.lr_budget == 0.0
+    trainer.fit()
+
+    assert trainer.n_training_steps > 0
+    assert trainer.lr_budget == pytest.approx(1e-3 * trainer.n_training_steps)
+
+
+def test_sae_trainer_logs_the_convergence_warning_returned_by_the_sae(
+    caplog: pytest.LogCaptureFixture,
+):
+    sae = StandardTrainingSAE(build_sae_training_cfg(d_in=8, d_sae=16))
+    seen_budgets: list[float] = []
+
+    def fake_warning(lr_budget: float) -> str:
+        seen_budgets.append(lr_budget)
+        return "l0_coefficient had no influence"
+
+    sae.training_convergence_warning = fake_warning  # type: ignore[method-assign]
+    trainer = _build_model_free_trainer(sae, lr=1e-3, lr_scheduler_name="constant")
+
+    with caplog.at_level(logging.WARNING, logger="sae_lens"):
+        trainer.fit()
+
+    assert "l0_coefficient had no influence" in caplog.text
+    assert seen_budgets == [pytest.approx(1e-3 * trainer.n_training_steps)]
+
+
+def test_sae_trainer_skips_the_convergence_warning_when_resuming(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Travel is measured from initialization, so it is meaningless on resume."""
+    sae = StandardTrainingSAE(build_sae_training_cfg(d_in=8, d_sae=16))
+    sae.training_convergence_warning = lambda _: "should not be logged"  # type: ignore[method-assign]
+    trainer = _build_model_free_trainer(sae, lr=1e-3, lr_scheduler_name="constant")
+    trainer.n_training_steps = 5  # pretend we resumed from a checkpoint
+
+    with caplog.at_level(logging.WARNING, logger="sae_lens"):
+        trainer.fit()
+
+    assert caplog.text == ""
+
+
+def test_sae_trainer_does_not_warn_for_architectures_without_the_diagnostic(
+    caplog: pytest.LogCaptureFixture,
+):
+    sae = StandardTrainingSAE(build_sae_training_cfg(d_in=8, d_sae=16))
+    trainer = _build_model_free_trainer(sae, lr=1e-3, lr_scheduler_name="constant")
+
+    with caplog.at_level(logging.WARNING, logger="sae_lens"):
+        trainer.fit()
+
+    assert caplog.text == ""


### PR DESCRIPTION
Addresses #719. Builds on #718 — that PR frees the JumpReLU threshold to move; this is about what happens once it can.

> **Note on the diff:** this branch is stacked on #718, so it carries that PR's four commits as well. Only the last commit (`docs: document that l0_coefficient saturates, and warn when it has`) is new here. It needs #718 because on `main` the threshold is a read-only `exp(log_threshold)` property that barely moves, so the diagnostic below can't apply. Happy to rebase once #718 lands, or to retarget it if #718 changes shape.

#719 reports that `l0_coefficient` does nothing across 1/10/100. It isn't inert, it saturates. Sweeping downward, on cached activations with `lr=3e-4`, bandwidth 0.05, init threshold 0.01, 2000 steps:

| `l0_coefficient` | 0 | 1e-3 | 1e-2 | 0.1 | 1 | 10 | 100 |
|---|---|---|---|---|---|---|---|
| final L0 | 478 | 364 | 124 | 36 | 26.6 | 26.4 | 26.0 |

The knob moves L0 10x over `[1e-3, 1e-1]` and is flat above ~1, so the values in the report were all past the point where it stops doing anything.

The threshold receives `c * g_l0 + g_mse`, and Adam fixes the step size at ~`lr`, so `c` only sets the *direction* of the update. Measured mid-training, the unit-`c` l0 gradient on the threshold is ~1000x the reconstruction gradient, so by `c ≈ 0.01` the direction is already entirely the l0 term and further increases are no-ops.

Where that boundary sits depends on activation scale, `jumprelu_bandwidth`, `d_sae`, batch size and `n_steps` — at 20k steps instead of 2k the same sweep is still responsive at `c=1 → 10`. So a better default wouldn't fix it.

**This PR doesn't change any optimization behaviour.** It:

- documents the saturation, scoped to `step` mode — in `tanh` mode the penalty also back-propagates through `W_enc`/`b_enc`/`W_dec` and `l0_coefficient` responds normally (L0 3.84 → 2.59 → 0.84 across c = 1/10/100), so the "only gradient path is the threshold" reasoning doesn't apply there
- warns at the end of training when the threshold travelled ≥90% of what Adam permits, which is the signal that the run is in the saturated regime

On the sweep above the warning fires at `c = 1` and `100` and stays quiet at `0.01` and `0.1`, which is the intended split.

Implementation is a no-op `TrainingSAE.training_convergence_warning()` hook, so other architectures are unaffected. It's skipped when resuming from a checkpoint, since travel is measured from initialization.

Two things I deliberately left alone: the `l0_coefficient=1.0` default (a behaviour change, and per the above no fixed value is right across setups), and the `5.0` in the `tanh` example, which isn't affected.

Happy to take this further — a target-L0 scheme is the option that would actually be robust to the scale-dependence — but that's a much larger change and a config-semantics decision, so I've kept this to documenting what the knob currently does.

Tests: 8 new, CPU-only, no model download. Existing suite passes.
