### PR TITLE
Gemma-scope-2 Neuronpedia aliases, in-place decoder-norm fold, and an activations-store device seam

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -2712,6 +2712,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_0_width_262k_l0_small_affine
     path: transcoder_all/layer_0_width_262k_l0_small_affine
     l0: 10
+    neuronpedia: gemma-3-4b-it/0-gemmascope-2-transcoder-262k
   - id: layer_10_width_16k_l0_big
     path: transcoder_all/layer_10_width_16k_l0_big
     l0: 112
@@ -2737,6 +2738,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_10_width_262k_l0_small_affine
     path: transcoder_all/layer_10_width_262k_l0_small_affine
     l0: 18
+    neuronpedia: gemma-3-4b-it/10-gemmascope-2-transcoder-262k
   - id: layer_11_width_16k_l0_big
     path: transcoder_all/layer_11_width_16k_l0_big
     l0: 118
@@ -2749,7 +2751,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_11_width_16k_l0_small_affine
     path: transcoder_all/layer_11_width_16k_l0_small_affine
     l0: 19
-    neuronpedia: gemma-3-4b-it/11-gemmascope-2-transcoder-16k
   - id: layer_11_width_262k_l0_big
     path: transcoder_all/layer_11_width_262k_l0_big
     l0: 118
@@ -2762,6 +2763,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_11_width_262k_l0_small_affine
     path: transcoder_all/layer_11_width_262k_l0_small_affine
     l0: 19
+    neuronpedia: gemma-3-4b-it/11-gemmascope-2-transcoder-262k
   - id: layer_12_width_16k_l0_big
     path: transcoder_all/layer_12_width_16k_l0_big
     l0: 120
@@ -2787,6 +2789,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_12_width_262k_l0_small_affine
     path: transcoder_all/layer_12_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/12-gemmascope-2-transcoder-262k
   - id: layer_13_width_16k_l0_big
     path: transcoder_all/layer_13_width_16k_l0_big
     l0: 120
@@ -2799,7 +2802,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_13_width_16k_l0_small_affine
     path: transcoder_all/layer_13_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/13-gemmascope-2-transcoder-16k
   - id: layer_13_width_262k_l0_big
     path: transcoder_all/layer_13_width_262k_l0_big
     l0: 120
@@ -2812,6 +2814,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_13_width_262k_l0_small_affine
     path: transcoder_all/layer_13_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/13-gemmascope-2-transcoder-262k
   - id: layer_14_width_16k_l0_big
     path: transcoder_all/layer_14_width_16k_l0_big
     l0: 120
@@ -2824,7 +2827,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_14_width_16k_l0_small_affine
     path: transcoder_all/layer_14_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/14-gemmascope-2-transcoder-16k
   - id: layer_14_width_262k_l0_big
     path: transcoder_all/layer_14_width_262k_l0_big
     l0: 120
@@ -2837,6 +2839,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_14_width_262k_l0_small_affine
     path: transcoder_all/layer_14_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/14-gemmascope-2-transcoder-262k
   - id: layer_15_width_16k_l0_big
     path: transcoder_all/layer_15_width_16k_l0_big
     l0: 120
@@ -2849,7 +2852,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_15_width_16k_l0_small_affine
     path: transcoder_all/layer_15_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/15-gemmascope-2-transcoder-16k
   - id: layer_15_width_262k_l0_big
     path: transcoder_all/layer_15_width_262k_l0_big
     l0: 120
@@ -2862,6 +2864,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_15_width_262k_l0_small_affine
     path: transcoder_all/layer_15_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/15-gemmascope-2-transcoder-262k
   - id: layer_16_width_16k_l0_big
     path: transcoder_all/layer_16_width_16k_l0_big
     l0: 120
@@ -2874,7 +2877,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_16_width_16k_l0_small_affine
     path: transcoder_all/layer_16_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/16-gemmascope-2-transcoder-16k
   - id: layer_16_width_262k_l0_big
     path: transcoder_all/layer_16_width_262k_l0_big
     l0: 120
@@ -2887,6 +2889,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_16_width_262k_l0_small_affine
     path: transcoder_all/layer_16_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/16-gemmascope-2-transcoder-262k
   - id: layer_17_width_16k_l0_big
     path: transcoder_all/layer_17_width_16k_l0_big
     l0: 120
@@ -2899,7 +2902,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_17_width_16k_l0_small_affine
     path: transcoder_all/layer_17_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/17-gemmascope-2-transcoder-16k
   - id: layer_17_width_262k_l0_big
     path: transcoder_all/layer_17_width_262k_l0_big
     l0: 120
@@ -2912,6 +2914,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_17_width_262k_l0_small_affine
     path: transcoder_all/layer_17_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/17-gemmascope-2-transcoder-262k
   - id: layer_18_width_16k_l0_big
     path: transcoder_all/layer_18_width_16k_l0_big
     l0: 120
@@ -2924,7 +2927,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_18_width_16k_l0_small_affine
     path: transcoder_all/layer_18_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/18-gemmascope-2-transcoder-16k
   - id: layer_18_width_262k_l0_big
     path: transcoder_all/layer_18_width_262k_l0_big
     l0: 120
@@ -2937,6 +2939,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_18_width_262k_l0_small_affine
     path: transcoder_all/layer_18_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/18-gemmascope-2-transcoder-262k
   - id: layer_19_width_16k_l0_big
     path: transcoder_all/layer_19_width_16k_l0_big
     l0: 120
@@ -2949,7 +2952,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_19_width_16k_l0_small_affine
     path: transcoder_all/layer_19_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/19-gemmascope-2-transcoder-16k
   - id: layer_19_width_262k_l0_big
     path: transcoder_all/layer_19_width_262k_l0_big
     l0: 120
@@ -2962,6 +2964,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_19_width_262k_l0_small_affine
     path: transcoder_all/layer_19_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/19-gemmascope-2-transcoder-262k
   - id: layer_1_width_16k_l0_big
     path: transcoder_all/layer_1_width_16k_l0_big
     l0: 65
@@ -2987,6 +2990,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_1_width_262k_l0_small_affine
     path: transcoder_all/layer_1_width_262k_l0_small_affine
     l0: 10
+    neuronpedia: gemma-3-4b-it/1-gemmascope-2-transcoder-262k
   - id: layer_20_width_16k_l0_big
     path: transcoder_all/layer_20_width_16k_l0_big
     l0: 120
@@ -2999,7 +3003,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_20_width_16k_l0_small_affine
     path: transcoder_all/layer_20_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/20-gemmascope-2-transcoder-16k
   - id: layer_20_width_262k_l0_big
     path: transcoder_all/layer_20_width_262k_l0_big
     l0: 120
@@ -3012,6 +3015,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_20_width_262k_l0_small_affine
     path: transcoder_all/layer_20_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/20-gemmascope-2-transcoder-262k
   - id: layer_21_width_16k_l0_big
     path: transcoder_all/layer_21_width_16k_l0_big
     l0: 120
@@ -3024,7 +3028,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_21_width_16k_l0_small_affine
     path: transcoder_all/layer_21_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/21-gemmascope-2-transcoder-16k
   - id: layer_21_width_262k_l0_big
     path: transcoder_all/layer_21_width_262k_l0_big
     l0: 120
@@ -3037,6 +3040,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_21_width_262k_l0_small_affine
     path: transcoder_all/layer_21_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/21-gemmascope-2-transcoder-262k
   - id: layer_22_width_16k_l0_big
     path: transcoder_all/layer_22_width_16k_l0_big
     l0: 120
@@ -3049,7 +3053,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_22_width_16k_l0_small_affine
     path: transcoder_all/layer_22_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/22-gemmascope-2-transcoder-16k
   - id: layer_22_width_262k_l0_big
     path: transcoder_all/layer_22_width_262k_l0_big
     l0: 120
@@ -3062,6 +3065,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_22_width_262k_l0_small_affine
     path: transcoder_all/layer_22_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/22-gemmascope-2-transcoder-262k
   - id: layer_23_width_16k_l0_big
     path: transcoder_all/layer_23_width_16k_l0_big
     l0: 120
@@ -3074,7 +3078,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_23_width_16k_l0_small_affine
     path: transcoder_all/layer_23_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/23-gemmascope-2-transcoder-16k
   - id: layer_23_width_262k_l0_big
     path: transcoder_all/layer_23_width_262k_l0_big
     l0: 120
@@ -3087,6 +3090,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_23_width_262k_l0_small_affine
     path: transcoder_all/layer_23_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/23-gemmascope-2-transcoder-262k
   - id: layer_24_width_16k_l0_big
     path: transcoder_all/layer_24_width_16k_l0_big
     l0: 120
@@ -3099,7 +3103,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_24_width_16k_l0_small_affine
     path: transcoder_all/layer_24_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/24-gemmascope-2-transcoder-16k
   - id: layer_24_width_262k_l0_big
     path: transcoder_all/layer_24_width_262k_l0_big
     l0: 120
@@ -3112,6 +3115,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_24_width_262k_l0_small_affine
     path: transcoder_all/layer_24_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/24-gemmascope-2-transcoder-262k
   - id: layer_25_width_16k_l0_big
     path: transcoder_all/layer_25_width_16k_l0_big
     l0: 120
@@ -3124,7 +3128,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_25_width_16k_l0_small_affine
     path: transcoder_all/layer_25_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/25-gemmascope-2-transcoder-16k
   - id: layer_25_width_262k_l0_big
     path: transcoder_all/layer_25_width_262k_l0_big
     l0: 120
@@ -3137,6 +3140,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_25_width_262k_l0_small_affine
     path: transcoder_all/layer_25_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/25-gemmascope-2-transcoder-262k
   - id: layer_26_width_16k_l0_big
     path: transcoder_all/layer_26_width_16k_l0_big
     l0: 120
@@ -3149,7 +3153,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_26_width_16k_l0_small_affine
     path: transcoder_all/layer_26_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/26-gemmascope-2-transcoder-16k
   - id: layer_26_width_262k_l0_big
     path: transcoder_all/layer_26_width_262k_l0_big
     l0: 120
@@ -3162,6 +3165,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_26_width_262k_l0_small_affine
     path: transcoder_all/layer_26_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/26-gemmascope-2-transcoder-262k
   - id: layer_27_width_16k_l0_big
     path: transcoder_all/layer_27_width_16k_l0_big
     l0: 120
@@ -3174,7 +3178,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_27_width_16k_l0_small_affine
     path: transcoder_all/layer_27_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/27-gemmascope-2-transcoder-16k
   - id: layer_27_width_262k_l0_big
     path: transcoder_all/layer_27_width_262k_l0_big
     l0: 120
@@ -3187,6 +3190,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_27_width_262k_l0_small_affine
     path: transcoder_all/layer_27_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/27-gemmascope-2-transcoder-262k
   - id: layer_28_width_16k_l0_big
     path: transcoder_all/layer_28_width_16k_l0_big
     l0: 120
@@ -3199,7 +3203,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_28_width_16k_l0_small_affine
     path: transcoder_all/layer_28_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/28-gemmascope-2-transcoder-16k
   - id: layer_28_width_262k_l0_big
     path: transcoder_all/layer_28_width_262k_l0_big
     l0: 120
@@ -3212,6 +3215,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_28_width_262k_l0_small_affine
     path: transcoder_all/layer_28_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/28-gemmascope-2-transcoder-262k
   - id: layer_29_width_16k_l0_big
     path: transcoder_all/layer_29_width_16k_l0_big
     l0: 120
@@ -3224,7 +3228,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_29_width_16k_l0_small_affine
     path: transcoder_all/layer_29_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/29-gemmascope-2-transcoder-16k
   - id: layer_29_width_262k_l0_big
     path: transcoder_all/layer_29_width_262k_l0_big
     l0: 120
@@ -3237,6 +3240,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_29_width_262k_l0_small_affine
     path: transcoder_all/layer_29_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/29-gemmascope-2-transcoder-262k
   - id: layer_2_width_16k_l0_big
     path: transcoder_all/layer_2_width_16k_l0_big
     l0: 70
@@ -3262,6 +3266,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_2_width_262k_l0_small_affine
     path: transcoder_all/layer_2_width_262k_l0_small_affine
     l0: 11
+    neuronpedia: gemma-3-4b-it/2-gemmascope-2-transcoder-262k
   - id: layer_30_width_16k_l0_big
     path: transcoder_all/layer_30_width_16k_l0_big
     l0: 120
@@ -3274,7 +3279,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_30_width_16k_l0_small_affine
     path: transcoder_all/layer_30_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/30-gemmascope-2-transcoder-16k
   - id: layer_30_width_262k_l0_big
     path: transcoder_all/layer_30_width_262k_l0_big
     l0: 120
@@ -3287,6 +3291,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_30_width_262k_l0_small_affine
     path: transcoder_all/layer_30_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/30-gemmascope-2-transcoder-262k
   - id: layer_31_width_16k_l0_big
     path: transcoder_all/layer_31_width_16k_l0_big
     l0: 120
@@ -3299,7 +3304,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_31_width_16k_l0_small_affine
     path: transcoder_all/layer_31_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/31-gemmascope-2-transcoder-16k
   - id: layer_31_width_262k_l0_big
     path: transcoder_all/layer_31_width_262k_l0_big
     l0: 120
@@ -3312,6 +3316,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_31_width_262k_l0_small_affine
     path: transcoder_all/layer_31_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/31-gemmascope-2-transcoder-262k
   - id: layer_32_width_16k_l0_big
     path: transcoder_all/layer_32_width_16k_l0_big
     l0: 120
@@ -3324,7 +3329,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_32_width_16k_l0_small_affine
     path: transcoder_all/layer_32_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/32-gemmascope-2-transcoder-16k
   - id: layer_32_width_262k_l0_big
     path: transcoder_all/layer_32_width_262k_l0_big
     l0: 120
@@ -3337,6 +3341,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_32_width_262k_l0_small_affine
     path: transcoder_all/layer_32_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/32-gemmascope-2-transcoder-262k
   - id: layer_33_width_16k_l0_big
     path: transcoder_all/layer_33_width_16k_l0_big
     l0: 120
@@ -3349,7 +3354,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_33_width_16k_l0_small_affine
     path: transcoder_all/layer_33_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-4b-it/33-gemmascope-2-transcoder-16k
   - id: layer_33_width_262k_l0_big
     path: transcoder_all/layer_33_width_262k_l0_big
     l0: 120
@@ -3362,6 +3366,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_33_width_262k_l0_small_affine
     path: transcoder_all/layer_33_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/33-gemmascope-2-transcoder-262k
   - id: layer_3_width_16k_l0_big
     path: transcoder_all/layer_3_width_16k_l0_big
     l0: 75
@@ -3387,6 +3392,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_3_width_262k_l0_small_affine
     path: transcoder_all/layer_3_width_262k_l0_small_affine
     l0: 12
+    neuronpedia: gemma-3-4b-it/3-gemmascope-2-transcoder-262k
   - id: layer_4_width_16k_l0_big
     path: transcoder_all/layer_4_width_16k_l0_big
     l0: 81
@@ -3412,6 +3418,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_4_width_262k_l0_small_affine
     path: transcoder_all/layer_4_width_262k_l0_small_affine
     l0: 13
+    neuronpedia: gemma-3-4b-it/4-gemmascope-2-transcoder-262k
   - id: layer_5_width_16k_l0_big
     path: transcoder_all/layer_5_width_16k_l0_big
     l0: 86
@@ -3424,7 +3431,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_5_width_16k_l0_small_affine
     path: transcoder_all/layer_5_width_16k_l0_small_affine
     l0: 14
-    neuronpedia: gemma-3-4b-it/5-gemmascope-2-transcoder-16k
   - id: layer_5_width_262k_l0_big
     path: transcoder_all/layer_5_width_262k_l0_big
     l0: 86
@@ -3437,6 +3443,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_5_width_262k_l0_small_affine
     path: transcoder_all/layer_5_width_262k_l0_small_affine
     l0: 14
+    neuronpedia: gemma-3-4b-it/5-gemmascope-2-transcoder-262k
   - id: layer_6_width_16k_l0_big
     path: transcoder_all/layer_6_width_16k_l0_big
     l0: 91
@@ -3462,6 +3469,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_6_width_262k_l0_small_affine
     path: transcoder_all/layer_6_width_262k_l0_small_affine
     l0: 15
+    neuronpedia: gemma-3-4b-it/6-gemmascope-2-transcoder-262k
   - id: layer_7_width_16k_l0_big
     path: transcoder_all/layer_7_width_16k_l0_big
     l0: 97
@@ -3487,6 +3495,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_7_width_262k_l0_small_affine
     path: transcoder_all/layer_7_width_262k_l0_small_affine
     l0: 16
+    neuronpedia: gemma-3-4b-it/7-gemmascope-2-transcoder-262k
   - id: layer_8_width_16k_l0_big
     path: transcoder_all/layer_8_width_16k_l0_big
     l0: 102
@@ -3499,7 +3508,6 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_8_width_16k_l0_small_affine
     path: transcoder_all/layer_8_width_16k_l0_small_affine
     l0: 17
-    neuronpedia: gemma-3-4b-it/8-gemmascope-2-transcoder-16k
   - id: layer_8_width_262k_l0_big
     path: transcoder_all/layer_8_width_262k_l0_big
     l0: 102
@@ -3512,6 +3520,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_8_width_262k_l0_small_affine
     path: transcoder_all/layer_8_width_262k_l0_small_affine
     l0: 17
+    neuronpedia: gemma-3-4b-it/8-gemmascope-2-transcoder-262k
   - id: layer_9_width_16k_l0_big
     path: transcoder_all/layer_9_width_16k_l0_big
     l0: 107
@@ -3537,6 +3546,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_9_width_262k_l0_small_affine
     path: transcoder_all/layer_9_width_262k_l0_small_affine
     l0: 17
+    neuronpedia: gemma-3-4b-it/9-gemmascope-2-transcoder-262k
 gemma-scope-2-4b-it-transcoders:
   conversion_func: gemma_3
   model: google/gemma-3-4b-it
@@ -15590,6 +15600,7 @@ gemma-scope-2-1b-pt-transcoders-all:
   - id: layer_15_width_16k_l0_small_affine
     path: transcoder_all/layer_15_width_16k_l0_small_affine
     l0: 20
+  - id: layer_15_width_262k_l0_big
     path: transcoder_all/layer_15_width_262k_l0_big
     l0: 120
   - id: layer_15_width_262k_l0_big_affine
@@ -15877,6 +15888,7 @@ gemma-scope-2-1b-pt-transcoders-all:
   - id: layer_2_width_16k_l0_small_affine
     path: transcoder_all/layer_2_width_16k_l0_small_affine
     l0: 12
+  - id: layer_2_width_262k_l0_big
     path: transcoder_all/layer_2_width_262k_l0_big
     l0: 73
   - id: layer_2_width_262k_l0_big_affine
@@ -17684,7 +17696,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_0_width_16k_l0_small_affine
     path: transcoder_all/layer_0_width_16k_l0_small_affine
     l0: 10
-    neuronpedia: gemma-3-1b-it/0-gemmascope-2-transcoder-16k
   - id: layer_0_width_262k_l0_big
     path: transcoder_all/layer_0_width_262k_l0_big
     l0: 60
@@ -17697,7 +17708,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_0_width_262k_l0_small_affine
     path: transcoder_all/layer_0_width_262k_l0_small_affine
     l0: 10
-    neuronpedia: gemma-3-1b-it/0-gemmascope-2-transcoder-262k
   - id: layer_10_width_16k_l0_big
     path: transcoder_all/layer_10_width_16k_l0_big
     l0: 120
@@ -17710,7 +17720,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_10_width_16k_l0_small_affine
     path: transcoder_all/layer_10_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/10-gemmascope-2-transcoder-16k
   - id: layer_10_width_262k_l0_big
     path: transcoder_all/layer_10_width_262k_l0_big
     l0: 120
@@ -17723,7 +17732,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_10_width_262k_l0_small_affine
     path: transcoder_all/layer_10_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/10-gemmascope-2-transcoder-262k
   - id: layer_11_width_16k_l0_big
     path: transcoder_all/layer_11_width_16k_l0_big
     l0: 120
@@ -17736,7 +17744,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_11_width_16k_l0_small_affine
     path: transcoder_all/layer_11_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/11-gemmascope-2-transcoder-16k
   - id: layer_11_width_262k_l0_big
     path: transcoder_all/layer_11_width_262k_l0_big
     l0: 120
@@ -17749,7 +17756,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_11_width_262k_l0_small_affine
     path: transcoder_all/layer_11_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/11-gemmascope-2-transcoder-262k
   - id: layer_12_width_16k_l0_big
     path: transcoder_all/layer_12_width_16k_l0_big
     l0: 120
@@ -17762,7 +17768,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_12_width_16k_l0_small_affine
     path: transcoder_all/layer_12_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/12-gemmascope-2-transcoder-16k
   - id: layer_12_width_262k_l0_big
     path: transcoder_all/layer_12_width_262k_l0_big
     l0: 120
@@ -17775,7 +17780,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_12_width_262k_l0_small_affine
     path: transcoder_all/layer_12_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/12-gemmascope-2-transcoder-262k
   - id: layer_13_width_16k_l0_big
     path: transcoder_all/layer_13_width_16k_l0_big
     l0: 120
@@ -17788,7 +17792,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_13_width_16k_l0_small_affine
     path: transcoder_all/layer_13_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/13-gemmascope-2-transcoder-16k
   - id: layer_13_width_262k_l0_big
     path: transcoder_all/layer_13_width_262k_l0_big
     l0: 120
@@ -17801,7 +17804,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_13_width_262k_l0_small_affine
     path: transcoder_all/layer_13_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/13-gemmascope-2-transcoder-262k
   - id: layer_14_width_16k_l0_big
     path: transcoder_all/layer_14_width_16k_l0_big
     l0: 120
@@ -17814,7 +17816,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_14_width_16k_l0_small_affine
     path: transcoder_all/layer_14_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/14-gemmascope-2-transcoder-16k
   - id: layer_14_width_262k_l0_big
     path: transcoder_all/layer_14_width_262k_l0_big
     l0: 120
@@ -17827,7 +17828,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_14_width_262k_l0_small_affine
     path: transcoder_all/layer_14_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/14-gemmascope-2-transcoder-262k
   - id: layer_15_width_16k_l0_big
     path: transcoder_all/layer_15_width_16k_l0_big
     l0: 120
@@ -17840,7 +17840,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_15_width_16k_l0_small_affine
     path: transcoder_all/layer_15_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/15-gemmascope-2-transcoder-16k
   - id: layer_15_width_262k_l0_big
     path: transcoder_all/layer_15_width_262k_l0_big
     l0: 120
@@ -17853,7 +17852,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_15_width_262k_l0_small_affine
     path: transcoder_all/layer_15_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/15-gemmascope-2-transcoder-262k
   - id: layer_16_width_16k_l0_big
     path: transcoder_all/layer_16_width_16k_l0_big
     l0: 120
@@ -17866,7 +17864,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_16_width_16k_l0_small_affine
     path: transcoder_all/layer_16_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/16-gemmascope-2-transcoder-16k
   - id: layer_16_width_262k_l0_big
     path: transcoder_all/layer_16_width_262k_l0_big
     l0: 120
@@ -17879,7 +17876,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_16_width_262k_l0_small_affine
     path: transcoder_all/layer_16_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/16-gemmascope-2-transcoder-262k
   - id: layer_17_width_16k_l0_big
     path: transcoder_all/layer_17_width_16k_l0_big
     l0: 120
@@ -17892,7 +17888,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_17_width_16k_l0_small_affine
     path: transcoder_all/layer_17_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/17-gemmascope-2-transcoder-16k
   - id: layer_17_width_262k_l0_big
     path: transcoder_all/layer_17_width_262k_l0_big
     l0: 120
@@ -17905,7 +17900,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_17_width_262k_l0_small_affine
     path: transcoder_all/layer_17_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/17-gemmascope-2-transcoder-262k
   - id: layer_18_width_16k_l0_big
     path: transcoder_all/layer_18_width_16k_l0_big
     l0: 120
@@ -17918,7 +17912,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_18_width_16k_l0_small_affine
     path: transcoder_all/layer_18_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/18-gemmascope-2-transcoder-16k
   - id: layer_18_width_262k_l0_big
     path: transcoder_all/layer_18_width_262k_l0_big
     l0: 120
@@ -17931,7 +17924,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_18_width_262k_l0_small_affine
     path: transcoder_all/layer_18_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/18-gemmascope-2-transcoder-262k
   - id: layer_19_width_16k_l0_big
     path: transcoder_all/layer_19_width_16k_l0_big
     l0: 120
@@ -17944,7 +17936,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_19_width_16k_l0_small_affine
     path: transcoder_all/layer_19_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/19-gemmascope-2-transcoder-16k
   - id: layer_19_width_262k_l0_big
     path: transcoder_all/layer_19_width_262k_l0_big
     l0: 120
@@ -17957,7 +17948,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_19_width_262k_l0_small_affine
     path: transcoder_all/layer_19_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/19-gemmascope-2-transcoder-262k
   - id: layer_1_width_16k_l0_big
     path: transcoder_all/layer_1_width_16k_l0_big
     l0: 66
@@ -17970,7 +17960,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_1_width_16k_l0_small_affine
     path: transcoder_all/layer_1_width_16k_l0_small_affine
     l0: 11
-    neuronpedia: gemma-3-1b-it/1-gemmascope-2-transcoder-16k
   - id: layer_1_width_262k_l0_big
     path: transcoder_all/layer_1_width_262k_l0_big
     l0: 66
@@ -17983,7 +17972,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_1_width_262k_l0_small_affine
     path: transcoder_all/layer_1_width_262k_l0_small_affine
     l0: 11
-    neuronpedia: gemma-3-1b-it/1-gemmascope-2-transcoder-262k
   - id: layer_20_width_16k_l0_big
     path: transcoder_all/layer_20_width_16k_l0_big
     l0: 120
@@ -17996,7 +17984,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_20_width_16k_l0_small_affine
     path: transcoder_all/layer_20_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/20-gemmascope-2-transcoder-16k
   - id: layer_20_width_262k_l0_big
     path: transcoder_all/layer_20_width_262k_l0_big
     l0: 120
@@ -18009,7 +17996,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_20_width_262k_l0_small_affine
     path: transcoder_all/layer_20_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/20-gemmascope-2-transcoder-262k
   - id: layer_21_width_16k_l0_big
     path: transcoder_all/layer_21_width_16k_l0_big
     l0: 120
@@ -18022,7 +18008,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_21_width_16k_l0_small_affine
     path: transcoder_all/layer_21_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/21-gemmascope-2-transcoder-16k
   - id: layer_21_width_262k_l0_big
     path: transcoder_all/layer_21_width_262k_l0_big
     l0: 120
@@ -18035,7 +18020,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_21_width_262k_l0_small_affine
     path: transcoder_all/layer_21_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/21-gemmascope-2-transcoder-262k
   - id: layer_22_width_16k_l0_big
     path: transcoder_all/layer_22_width_16k_l0_big
     l0: 120
@@ -18048,7 +18032,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_22_width_16k_l0_small_affine
     path: transcoder_all/layer_22_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/22-gemmascope-2-transcoder-16k
   - id: layer_22_width_262k_l0_big
     path: transcoder_all/layer_22_width_262k_l0_big
     l0: 120
@@ -18061,7 +18044,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_22_width_262k_l0_small_affine
     path: transcoder_all/layer_22_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/22-gemmascope-2-transcoder-262k
   - id: layer_23_width_16k_l0_big
     path: transcoder_all/layer_23_width_16k_l0_big
     l0: 120
@@ -18074,7 +18056,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_23_width_16k_l0_small_affine
     path: transcoder_all/layer_23_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/23-gemmascope-2-transcoder-16k
   - id: layer_23_width_262k_l0_big
     path: transcoder_all/layer_23_width_262k_l0_big
     l0: 120
@@ -18087,7 +18068,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_23_width_262k_l0_small_affine
     path: transcoder_all/layer_23_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/23-gemmascope-2-transcoder-262k
   - id: layer_24_width_16k_l0_big
     path: transcoder_all/layer_24_width_16k_l0_big
     l0: 120
@@ -18100,7 +18080,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_24_width_16k_l0_small_affine
     path: transcoder_all/layer_24_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/24-gemmascope-2-transcoder-16k
   - id: layer_24_width_262k_l0_big
     path: transcoder_all/layer_24_width_262k_l0_big
     l0: 120
@@ -18113,7 +18092,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_24_width_262k_l0_small_affine
     path: transcoder_all/layer_24_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/24-gemmascope-2-transcoder-262k
   - id: layer_25_width_16k_l0_big
     path: transcoder_all/layer_25_width_16k_l0_big
     l0: 120
@@ -18126,7 +18104,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_25_width_16k_l0_small_affine
     path: transcoder_all/layer_25_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/25-gemmascope-2-transcoder-16k
   - id: layer_25_width_262k_l0_big
     path: transcoder_all/layer_25_width_262k_l0_big
     l0: 120
@@ -18139,7 +18116,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_25_width_262k_l0_small_affine
     path: transcoder_all/layer_25_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/25-gemmascope-2-transcoder-262k
   - id: layer_2_width_16k_l0_big
     path: transcoder_all/layer_2_width_16k_l0_big
     l0: 73
@@ -18152,7 +18128,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_2_width_16k_l0_small_affine
     path: transcoder_all/layer_2_width_16k_l0_small_affine
     l0: 12
-    neuronpedia: gemma-3-1b-it/2-gemmascope-2-transcoder-16k
   - id: layer_2_width_262k_l0_big
     path: transcoder_all/layer_2_width_262k_l0_big
     l0: 73
@@ -18165,7 +18140,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_2_width_262k_l0_small_affine
     path: transcoder_all/layer_2_width_262k_l0_small_affine
     l0: 12
-    neuronpedia: gemma-3-1b-it/2-gemmascope-2-transcoder-262k
   - id: layer_3_width_16k_l0_big
     path: transcoder_all/layer_3_width_16k_l0_big
     l0: 80
@@ -18178,7 +18152,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_3_width_16k_l0_small_affine
     path: transcoder_all/layer_3_width_16k_l0_small_affine
     l0: 13
-    neuronpedia: gemma-3-1b-it/3-gemmascope-2-transcoder-16k
   - id: layer_3_width_262k_l0_big
     path: transcoder_all/layer_3_width_262k_l0_big
     l0: 80
@@ -18191,7 +18164,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_3_width_262k_l0_small_affine
     path: transcoder_all/layer_3_width_262k_l0_small_affine
     l0: 13
-    neuronpedia: gemma-3-1b-it/3-gemmascope-2-transcoder-262k
   - id: layer_4_width_16k_l0_big
     path: transcoder_all/layer_4_width_16k_l0_big
     l0: 87
@@ -18204,7 +18176,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_4_width_16k_l0_small_affine
     path: transcoder_all/layer_4_width_16k_l0_small_affine
     l0: 14
-    neuronpedia: gemma-3-1b-it/4-gemmascope-2-transcoder-16k
   - id: layer_4_width_262k_l0_big
     path: transcoder_all/layer_4_width_262k_l0_big
     l0: 87
@@ -18217,7 +18188,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_4_width_262k_l0_small_affine
     path: transcoder_all/layer_4_width_262k_l0_small_affine
     l0: 14
-    neuronpedia: gemma-3-1b-it/4-gemmascope-2-transcoder-262k
   - id: layer_5_width_16k_l0_big
     path: transcoder_all/layer_5_width_16k_l0_big
     l0: 94
@@ -18230,7 +18200,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_5_width_16k_l0_small_affine
     path: transcoder_all/layer_5_width_16k_l0_small_affine
     l0: 15
-    neuronpedia: gemma-3-1b-it/5-gemmascope-2-transcoder-16k
   - id: layer_5_width_262k_l0_big
     path: transcoder_all/layer_5_width_262k_l0_big
     l0: 94
@@ -18243,7 +18212,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_5_width_262k_l0_small_affine
     path: transcoder_all/layer_5_width_262k_l0_small_affine
     l0: 15
-    neuronpedia: gemma-3-1b-it/5-gemmascope-2-transcoder-262k
   - id: layer_6_width_16k_l0_big
     path: transcoder_all/layer_6_width_16k_l0_big
     l0: 101
@@ -18256,7 +18224,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_6_width_16k_l0_small_affine
     path: transcoder_all/layer_6_width_16k_l0_small_affine
     l0: 16
-    neuronpedia: gemma-3-1b-it/6-gemmascope-2-transcoder-16k
   - id: layer_6_width_262k_l0_big
     path: transcoder_all/layer_6_width_262k_l0_big
     l0: 101
@@ -18269,7 +18236,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_6_width_262k_l0_small_affine
     path: transcoder_all/layer_6_width_262k_l0_small_affine
     l0: 16
-    neuronpedia: gemma-3-1b-it/6-gemmascope-2-transcoder-262k
   - id: layer_7_width_16k_l0_big
     path: transcoder_all/layer_7_width_16k_l0_big
     l0: 108
@@ -18282,7 +18248,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_7_width_16k_l0_small_affine
     path: transcoder_all/layer_7_width_16k_l0_small_affine
     l0: 18
-    neuronpedia: gemma-3-1b-it/7-gemmascope-2-transcoder-16k
   - id: layer_7_width_262k_l0_big
     path: transcoder_all/layer_7_width_262k_l0_big
     l0: 108
@@ -18295,7 +18260,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_7_width_262k_l0_small_affine
     path: transcoder_all/layer_7_width_262k_l0_small_affine
     l0: 18
-    neuronpedia: gemma-3-1b-it/7-gemmascope-2-transcoder-262k
   - id: layer_8_width_16k_l0_big
     path: transcoder_all/layer_8_width_16k_l0_big
     l0: 115
@@ -18308,7 +18272,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_8_width_16k_l0_small_affine
     path: transcoder_all/layer_8_width_16k_l0_small_affine
     l0: 19
-    neuronpedia: gemma-3-1b-it/8-gemmascope-2-transcoder-16k
   - id: layer_8_width_262k_l0_big
     path: transcoder_all/layer_8_width_262k_l0_big
     l0: 115
@@ -18321,7 +18284,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_8_width_262k_l0_small_affine
     path: transcoder_all/layer_8_width_262k_l0_small_affine
     l0: 19
-    neuronpedia: gemma-3-1b-it/8-gemmascope-2-transcoder-262k
   - id: layer_9_width_16k_l0_big
     path: transcoder_all/layer_9_width_16k_l0_big
     l0: 120
@@ -18334,7 +18296,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_9_width_16k_l0_small_affine
     path: transcoder_all/layer_9_width_16k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/9-gemmascope-2-transcoder-16k
   - id: layer_9_width_262k_l0_big
     path: transcoder_all/layer_9_width_262k_l0_big
     l0: 120
@@ -18347,7 +18308,6 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_9_width_262k_l0_small_affine
     path: transcoder_all/layer_9_width_262k_l0_small_affine
     l0: 20
-    neuronpedia: gemma-3-1b-it/9-gemmascope-2-transcoder-262k
 gemma-scope-2-1b-it-transcoders:
   conversion_func: gemma_3
   model: google/gemma-3-1b-it
@@ -19984,6 +19944,7 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_0_width_262k_l0_small_affine
     path: transcoder_all/layer_0_width_262k_l0_small_affine
     l0: 10
+  - id: layer_10_width_16k_l0_big
     path: transcoder_all/layer_10_width_16k_l0_big
     l0: 97
   - id: layer_10_width_16k_l0_big_affine
@@ -20007,6 +19968,7 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_10_width_262k_l0_small_affine
     path: transcoder_all/layer_10_width_262k_l0_small_affine
     l0: 16
+  - id: layer_11_width_16k_l0_big
     path: transcoder_all/layer_11_width_16k_l0_big
     l0: 101
   - id: layer_11_width_16k_l0_big_affine
@@ -20030,6 +19992,7 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_11_width_262k_l0_small_affine
     path: transcoder_all/layer_11_width_262k_l0_small_affine
     l0: 16
+  - id: layer_12_width_16k_l0_big
     path: transcoder_all/layer_12_width_16k_l0_big
     l0: 105
   - id: layer_12_width_16k_l0_big_affine
@@ -20053,6 +20016,7 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_12_width_262k_l0_small_affine
     path: transcoder_all/layer_12_width_262k_l0_small_affine
     l0: 17
+  - id: layer_13_width_16k_l0_big
     path: transcoder_all/layer_13_width_16k_l0_big
     l0: 108
   - id: layer_13_width_16k_l0_big_affine
@@ -20076,6 +20040,7 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_13_width_262k_l0_small_affine
     path: transcoder_all/layer_13_width_262k_l0_small_affine
     l0: 18
+  - id: layer_14_width_16k_l0_big
     path: transcoder_all/layer_14_width_16k_l0_big
     l0: 112
   - id: layer_14_width_16k_l0_big_affine
@@ -20099,6 +20064,7 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_14_width_262k_l0_small_affine
     path: transcoder_all/layer_14_width_262k_l0_small_affine
     l0: 18
+  - id: layer_15_width_16k_l0_big
     path: transcoder_all/layer_15_width_16k_l0_big
     l0: 116
   - id: layer_15_width_16k_l0_big_affine
@@ -20122,6 +20088,7 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_15_width_262k_l0_small_affine
     path: transcoder_all/layer_15_width_262k_l0_small_affine
     l0: 19
+  - id: layer_16_width_16k_l0_big
     path: transcoder_all/layer_16_width_16k_l0_big
     l0: 120
   - id: layer_16_width_16k_l0_big_affine
@@ -20145,6 +20112,7 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_16_width_262k_l0_small_affine
     path: transcoder_all/layer_16_width_262k_l0_small_affine
     l0: 20
+  - id: layer_17_width_16k_l0_big
     path: transcoder_all/layer_17_width_16k_l0_big
     l0: 120
   - id: layer_17_width_16k_l0_big_affine

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -2699,6 +2699,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_0_width_16k_l0_small_affine
     path: transcoder_all/layer_0_width_16k_l0_small_affine
     l0: 10
+    neuronpedia: gemma-3-4b-it/0-gemmascope-2-transcoder-16k
   - id: layer_0_width_262k_l0_big
     path: transcoder_all/layer_0_width_262k_l0_big
     l0: 60
@@ -2723,6 +2724,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_10_width_16k_l0_small_affine
     path: transcoder_all/layer_10_width_16k_l0_small_affine
     l0: 18
+    neuronpedia: gemma-3-4b-it/10-gemmascope-2-transcoder-16k
   - id: layer_10_width_262k_l0_big
     path: transcoder_all/layer_10_width_262k_l0_big
     l0: 112
@@ -2747,6 +2749,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_11_width_16k_l0_small_affine
     path: transcoder_all/layer_11_width_16k_l0_small_affine
     l0: 19
+    neuronpedia: gemma-3-4b-it/11-gemmascope-2-transcoder-16k
   - id: layer_11_width_262k_l0_big
     path: transcoder_all/layer_11_width_262k_l0_big
     l0: 118
@@ -2771,6 +2774,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_12_width_16k_l0_small_affine
     path: transcoder_all/layer_12_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/12-gemmascope-2-transcoder-16k
   - id: layer_12_width_262k_l0_big
     path: transcoder_all/layer_12_width_262k_l0_big
     l0: 120
@@ -2795,6 +2799,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_13_width_16k_l0_small_affine
     path: transcoder_all/layer_13_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/13-gemmascope-2-transcoder-16k
   - id: layer_13_width_262k_l0_big
     path: transcoder_all/layer_13_width_262k_l0_big
     l0: 120
@@ -2819,6 +2824,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_14_width_16k_l0_small_affine
     path: transcoder_all/layer_14_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/14-gemmascope-2-transcoder-16k
   - id: layer_14_width_262k_l0_big
     path: transcoder_all/layer_14_width_262k_l0_big
     l0: 120
@@ -2843,6 +2849,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_15_width_16k_l0_small_affine
     path: transcoder_all/layer_15_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/15-gemmascope-2-transcoder-16k
   - id: layer_15_width_262k_l0_big
     path: transcoder_all/layer_15_width_262k_l0_big
     l0: 120
@@ -2867,6 +2874,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_16_width_16k_l0_small_affine
     path: transcoder_all/layer_16_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/16-gemmascope-2-transcoder-16k
   - id: layer_16_width_262k_l0_big
     path: transcoder_all/layer_16_width_262k_l0_big
     l0: 120
@@ -2891,6 +2899,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_17_width_16k_l0_small_affine
     path: transcoder_all/layer_17_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/17-gemmascope-2-transcoder-16k
   - id: layer_17_width_262k_l0_big
     path: transcoder_all/layer_17_width_262k_l0_big
     l0: 120
@@ -2915,6 +2924,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_18_width_16k_l0_small_affine
     path: transcoder_all/layer_18_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/18-gemmascope-2-transcoder-16k
   - id: layer_18_width_262k_l0_big
     path: transcoder_all/layer_18_width_262k_l0_big
     l0: 120
@@ -2939,6 +2949,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_19_width_16k_l0_small_affine
     path: transcoder_all/layer_19_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/19-gemmascope-2-transcoder-16k
   - id: layer_19_width_262k_l0_big
     path: transcoder_all/layer_19_width_262k_l0_big
     l0: 120
@@ -2963,6 +2974,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_1_width_16k_l0_small_affine
     path: transcoder_all/layer_1_width_16k_l0_small_affine
     l0: 10
+    neuronpedia: gemma-3-4b-it/1-gemmascope-2-transcoder-16k
   - id: layer_1_width_262k_l0_big
     path: transcoder_all/layer_1_width_262k_l0_big
     l0: 65
@@ -2987,6 +2999,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_20_width_16k_l0_small_affine
     path: transcoder_all/layer_20_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/20-gemmascope-2-transcoder-16k
   - id: layer_20_width_262k_l0_big
     path: transcoder_all/layer_20_width_262k_l0_big
     l0: 120
@@ -3011,6 +3024,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_21_width_16k_l0_small_affine
     path: transcoder_all/layer_21_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/21-gemmascope-2-transcoder-16k
   - id: layer_21_width_262k_l0_big
     path: transcoder_all/layer_21_width_262k_l0_big
     l0: 120
@@ -3035,6 +3049,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_22_width_16k_l0_small_affine
     path: transcoder_all/layer_22_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/22-gemmascope-2-transcoder-16k
   - id: layer_22_width_262k_l0_big
     path: transcoder_all/layer_22_width_262k_l0_big
     l0: 120
@@ -3059,6 +3074,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_23_width_16k_l0_small_affine
     path: transcoder_all/layer_23_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/23-gemmascope-2-transcoder-16k
   - id: layer_23_width_262k_l0_big
     path: transcoder_all/layer_23_width_262k_l0_big
     l0: 120
@@ -3083,6 +3099,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_24_width_16k_l0_small_affine
     path: transcoder_all/layer_24_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/24-gemmascope-2-transcoder-16k
   - id: layer_24_width_262k_l0_big
     path: transcoder_all/layer_24_width_262k_l0_big
     l0: 120
@@ -3107,6 +3124,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_25_width_16k_l0_small_affine
     path: transcoder_all/layer_25_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/25-gemmascope-2-transcoder-16k
   - id: layer_25_width_262k_l0_big
     path: transcoder_all/layer_25_width_262k_l0_big
     l0: 120
@@ -3131,6 +3149,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_26_width_16k_l0_small_affine
     path: transcoder_all/layer_26_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/26-gemmascope-2-transcoder-16k
   - id: layer_26_width_262k_l0_big
     path: transcoder_all/layer_26_width_262k_l0_big
     l0: 120
@@ -3155,6 +3174,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_27_width_16k_l0_small_affine
     path: transcoder_all/layer_27_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/27-gemmascope-2-transcoder-16k
   - id: layer_27_width_262k_l0_big
     path: transcoder_all/layer_27_width_262k_l0_big
     l0: 120
@@ -3179,6 +3199,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_28_width_16k_l0_small_affine
     path: transcoder_all/layer_28_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/28-gemmascope-2-transcoder-16k
   - id: layer_28_width_262k_l0_big
     path: transcoder_all/layer_28_width_262k_l0_big
     l0: 120
@@ -3203,6 +3224,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_29_width_16k_l0_small_affine
     path: transcoder_all/layer_29_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/29-gemmascope-2-transcoder-16k
   - id: layer_29_width_262k_l0_big
     path: transcoder_all/layer_29_width_262k_l0_big
     l0: 120
@@ -3227,6 +3249,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_2_width_16k_l0_small_affine
     path: transcoder_all/layer_2_width_16k_l0_small_affine
     l0: 11
+    neuronpedia: gemma-3-4b-it/2-gemmascope-2-transcoder-16k
   - id: layer_2_width_262k_l0_big
     path: transcoder_all/layer_2_width_262k_l0_big
     l0: 70
@@ -3251,6 +3274,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_30_width_16k_l0_small_affine
     path: transcoder_all/layer_30_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/30-gemmascope-2-transcoder-16k
   - id: layer_30_width_262k_l0_big
     path: transcoder_all/layer_30_width_262k_l0_big
     l0: 120
@@ -3275,6 +3299,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_31_width_16k_l0_small_affine
     path: transcoder_all/layer_31_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/31-gemmascope-2-transcoder-16k
   - id: layer_31_width_262k_l0_big
     path: transcoder_all/layer_31_width_262k_l0_big
     l0: 120
@@ -3299,6 +3324,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_32_width_16k_l0_small_affine
     path: transcoder_all/layer_32_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/32-gemmascope-2-transcoder-16k
   - id: layer_32_width_262k_l0_big
     path: transcoder_all/layer_32_width_262k_l0_big
     l0: 120
@@ -3323,6 +3349,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_33_width_16k_l0_small_affine
     path: transcoder_all/layer_33_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-4b-it/33-gemmascope-2-transcoder-16k
   - id: layer_33_width_262k_l0_big
     path: transcoder_all/layer_33_width_262k_l0_big
     l0: 120
@@ -3347,6 +3374,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_3_width_16k_l0_small_affine
     path: transcoder_all/layer_3_width_16k_l0_small_affine
     l0: 12
+    neuronpedia: gemma-3-4b-it/3-gemmascope-2-transcoder-16k
   - id: layer_3_width_262k_l0_big
     path: transcoder_all/layer_3_width_262k_l0_big
     l0: 75
@@ -3371,6 +3399,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_4_width_16k_l0_small_affine
     path: transcoder_all/layer_4_width_16k_l0_small_affine
     l0: 13
+    neuronpedia: gemma-3-4b-it/4-gemmascope-2-transcoder-16k
   - id: layer_4_width_262k_l0_big
     path: transcoder_all/layer_4_width_262k_l0_big
     l0: 81
@@ -3395,6 +3424,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_5_width_16k_l0_small_affine
     path: transcoder_all/layer_5_width_16k_l0_small_affine
     l0: 14
+    neuronpedia: gemma-3-4b-it/5-gemmascope-2-transcoder-16k
   - id: layer_5_width_262k_l0_big
     path: transcoder_all/layer_5_width_262k_l0_big
     l0: 86
@@ -3419,6 +3449,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_6_width_16k_l0_small_affine
     path: transcoder_all/layer_6_width_16k_l0_small_affine
     l0: 15
+    neuronpedia: gemma-3-4b-it/6-gemmascope-2-transcoder-16k
   - id: layer_6_width_262k_l0_big
     path: transcoder_all/layer_6_width_262k_l0_big
     l0: 91
@@ -3443,6 +3474,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_7_width_16k_l0_small_affine
     path: transcoder_all/layer_7_width_16k_l0_small_affine
     l0: 16
+    neuronpedia: gemma-3-4b-it/7-gemmascope-2-transcoder-16k
   - id: layer_7_width_262k_l0_big
     path: transcoder_all/layer_7_width_262k_l0_big
     l0: 97
@@ -3467,6 +3499,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_8_width_16k_l0_small_affine
     path: transcoder_all/layer_8_width_16k_l0_small_affine
     l0: 17
+    neuronpedia: gemma-3-4b-it/8-gemmascope-2-transcoder-16k
   - id: layer_8_width_262k_l0_big
     path: transcoder_all/layer_8_width_262k_l0_big
     l0: 102
@@ -3491,6 +3524,7 @@ gemma-scope-2-4b-it-transcoders-all:
   - id: layer_9_width_16k_l0_small_affine
     path: transcoder_all/layer_9_width_16k_l0_small_affine
     l0: 17
+    neuronpedia: gemma-3-4b-it/9-gemmascope-2-transcoder-16k
   - id: layer_9_width_262k_l0_big
     path: transcoder_all/layer_9_width_262k_l0_big
     l0: 107
@@ -15556,7 +15590,6 @@ gemma-scope-2-1b-pt-transcoders-all:
   - id: layer_15_width_16k_l0_small_affine
     path: transcoder_all/layer_15_width_16k_l0_small_affine
     l0: 20
-  - id: layer_15_width_262k_l0_big
     path: transcoder_all/layer_15_width_262k_l0_big
     l0: 120
   - id: layer_15_width_262k_l0_big_affine
@@ -15844,7 +15877,6 @@ gemma-scope-2-1b-pt-transcoders-all:
   - id: layer_2_width_16k_l0_small_affine
     path: transcoder_all/layer_2_width_16k_l0_small_affine
     l0: 12
-  - id: layer_2_width_262k_l0_big
     path: transcoder_all/layer_2_width_262k_l0_big
     l0: 73
   - id: layer_2_width_262k_l0_big_affine
@@ -17652,6 +17684,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_0_width_16k_l0_small_affine
     path: transcoder_all/layer_0_width_16k_l0_small_affine
     l0: 10
+    neuronpedia: gemma-3-1b-it/0-gemmascope-2-transcoder-16k
   - id: layer_0_width_262k_l0_big
     path: transcoder_all/layer_0_width_262k_l0_big
     l0: 60
@@ -17664,6 +17697,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_0_width_262k_l0_small_affine
     path: transcoder_all/layer_0_width_262k_l0_small_affine
     l0: 10
+    neuronpedia: gemma-3-1b-it/0-gemmascope-2-transcoder-262k
   - id: layer_10_width_16k_l0_big
     path: transcoder_all/layer_10_width_16k_l0_big
     l0: 120
@@ -17676,6 +17710,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_10_width_16k_l0_small_affine
     path: transcoder_all/layer_10_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/10-gemmascope-2-transcoder-16k
   - id: layer_10_width_262k_l0_big
     path: transcoder_all/layer_10_width_262k_l0_big
     l0: 120
@@ -17688,6 +17723,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_10_width_262k_l0_small_affine
     path: transcoder_all/layer_10_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/10-gemmascope-2-transcoder-262k
   - id: layer_11_width_16k_l0_big
     path: transcoder_all/layer_11_width_16k_l0_big
     l0: 120
@@ -17700,6 +17736,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_11_width_16k_l0_small_affine
     path: transcoder_all/layer_11_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/11-gemmascope-2-transcoder-16k
   - id: layer_11_width_262k_l0_big
     path: transcoder_all/layer_11_width_262k_l0_big
     l0: 120
@@ -17712,6 +17749,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_11_width_262k_l0_small_affine
     path: transcoder_all/layer_11_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/11-gemmascope-2-transcoder-262k
   - id: layer_12_width_16k_l0_big
     path: transcoder_all/layer_12_width_16k_l0_big
     l0: 120
@@ -17724,6 +17762,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_12_width_16k_l0_small_affine
     path: transcoder_all/layer_12_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/12-gemmascope-2-transcoder-16k
   - id: layer_12_width_262k_l0_big
     path: transcoder_all/layer_12_width_262k_l0_big
     l0: 120
@@ -17736,6 +17775,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_12_width_262k_l0_small_affine
     path: transcoder_all/layer_12_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/12-gemmascope-2-transcoder-262k
   - id: layer_13_width_16k_l0_big
     path: transcoder_all/layer_13_width_16k_l0_big
     l0: 120
@@ -17748,6 +17788,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_13_width_16k_l0_small_affine
     path: transcoder_all/layer_13_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/13-gemmascope-2-transcoder-16k
   - id: layer_13_width_262k_l0_big
     path: transcoder_all/layer_13_width_262k_l0_big
     l0: 120
@@ -17760,6 +17801,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_13_width_262k_l0_small_affine
     path: transcoder_all/layer_13_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/13-gemmascope-2-transcoder-262k
   - id: layer_14_width_16k_l0_big
     path: transcoder_all/layer_14_width_16k_l0_big
     l0: 120
@@ -17772,6 +17814,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_14_width_16k_l0_small_affine
     path: transcoder_all/layer_14_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/14-gemmascope-2-transcoder-16k
   - id: layer_14_width_262k_l0_big
     path: transcoder_all/layer_14_width_262k_l0_big
     l0: 120
@@ -17784,6 +17827,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_14_width_262k_l0_small_affine
     path: transcoder_all/layer_14_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/14-gemmascope-2-transcoder-262k
   - id: layer_15_width_16k_l0_big
     path: transcoder_all/layer_15_width_16k_l0_big
     l0: 120
@@ -17796,6 +17840,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_15_width_16k_l0_small_affine
     path: transcoder_all/layer_15_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/15-gemmascope-2-transcoder-16k
   - id: layer_15_width_262k_l0_big
     path: transcoder_all/layer_15_width_262k_l0_big
     l0: 120
@@ -17808,6 +17853,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_15_width_262k_l0_small_affine
     path: transcoder_all/layer_15_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/15-gemmascope-2-transcoder-262k
   - id: layer_16_width_16k_l0_big
     path: transcoder_all/layer_16_width_16k_l0_big
     l0: 120
@@ -17820,6 +17866,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_16_width_16k_l0_small_affine
     path: transcoder_all/layer_16_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/16-gemmascope-2-transcoder-16k
   - id: layer_16_width_262k_l0_big
     path: transcoder_all/layer_16_width_262k_l0_big
     l0: 120
@@ -17832,6 +17879,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_16_width_262k_l0_small_affine
     path: transcoder_all/layer_16_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/16-gemmascope-2-transcoder-262k
   - id: layer_17_width_16k_l0_big
     path: transcoder_all/layer_17_width_16k_l0_big
     l0: 120
@@ -17844,6 +17892,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_17_width_16k_l0_small_affine
     path: transcoder_all/layer_17_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/17-gemmascope-2-transcoder-16k
   - id: layer_17_width_262k_l0_big
     path: transcoder_all/layer_17_width_262k_l0_big
     l0: 120
@@ -17856,6 +17905,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_17_width_262k_l0_small_affine
     path: transcoder_all/layer_17_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/17-gemmascope-2-transcoder-262k
   - id: layer_18_width_16k_l0_big
     path: transcoder_all/layer_18_width_16k_l0_big
     l0: 120
@@ -17868,6 +17918,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_18_width_16k_l0_small_affine
     path: transcoder_all/layer_18_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/18-gemmascope-2-transcoder-16k
   - id: layer_18_width_262k_l0_big
     path: transcoder_all/layer_18_width_262k_l0_big
     l0: 120
@@ -17880,6 +17931,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_18_width_262k_l0_small_affine
     path: transcoder_all/layer_18_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/18-gemmascope-2-transcoder-262k
   - id: layer_19_width_16k_l0_big
     path: transcoder_all/layer_19_width_16k_l0_big
     l0: 120
@@ -17892,6 +17944,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_19_width_16k_l0_small_affine
     path: transcoder_all/layer_19_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/19-gemmascope-2-transcoder-16k
   - id: layer_19_width_262k_l0_big
     path: transcoder_all/layer_19_width_262k_l0_big
     l0: 120
@@ -17904,6 +17957,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_19_width_262k_l0_small_affine
     path: transcoder_all/layer_19_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/19-gemmascope-2-transcoder-262k
   - id: layer_1_width_16k_l0_big
     path: transcoder_all/layer_1_width_16k_l0_big
     l0: 66
@@ -17916,6 +17970,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_1_width_16k_l0_small_affine
     path: transcoder_all/layer_1_width_16k_l0_small_affine
     l0: 11
+    neuronpedia: gemma-3-1b-it/1-gemmascope-2-transcoder-16k
   - id: layer_1_width_262k_l0_big
     path: transcoder_all/layer_1_width_262k_l0_big
     l0: 66
@@ -17928,6 +17983,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_1_width_262k_l0_small_affine
     path: transcoder_all/layer_1_width_262k_l0_small_affine
     l0: 11
+    neuronpedia: gemma-3-1b-it/1-gemmascope-2-transcoder-262k
   - id: layer_20_width_16k_l0_big
     path: transcoder_all/layer_20_width_16k_l0_big
     l0: 120
@@ -17940,6 +17996,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_20_width_16k_l0_small_affine
     path: transcoder_all/layer_20_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/20-gemmascope-2-transcoder-16k
   - id: layer_20_width_262k_l0_big
     path: transcoder_all/layer_20_width_262k_l0_big
     l0: 120
@@ -17952,6 +18009,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_20_width_262k_l0_small_affine
     path: transcoder_all/layer_20_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/20-gemmascope-2-transcoder-262k
   - id: layer_21_width_16k_l0_big
     path: transcoder_all/layer_21_width_16k_l0_big
     l0: 120
@@ -17964,6 +18022,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_21_width_16k_l0_small_affine
     path: transcoder_all/layer_21_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/21-gemmascope-2-transcoder-16k
   - id: layer_21_width_262k_l0_big
     path: transcoder_all/layer_21_width_262k_l0_big
     l0: 120
@@ -17976,6 +18035,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_21_width_262k_l0_small_affine
     path: transcoder_all/layer_21_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/21-gemmascope-2-transcoder-262k
   - id: layer_22_width_16k_l0_big
     path: transcoder_all/layer_22_width_16k_l0_big
     l0: 120
@@ -17988,6 +18048,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_22_width_16k_l0_small_affine
     path: transcoder_all/layer_22_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/22-gemmascope-2-transcoder-16k
   - id: layer_22_width_262k_l0_big
     path: transcoder_all/layer_22_width_262k_l0_big
     l0: 120
@@ -18000,6 +18061,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_22_width_262k_l0_small_affine
     path: transcoder_all/layer_22_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/22-gemmascope-2-transcoder-262k
   - id: layer_23_width_16k_l0_big
     path: transcoder_all/layer_23_width_16k_l0_big
     l0: 120
@@ -18012,6 +18074,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_23_width_16k_l0_small_affine
     path: transcoder_all/layer_23_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/23-gemmascope-2-transcoder-16k
   - id: layer_23_width_262k_l0_big
     path: transcoder_all/layer_23_width_262k_l0_big
     l0: 120
@@ -18024,6 +18087,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_23_width_262k_l0_small_affine
     path: transcoder_all/layer_23_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/23-gemmascope-2-transcoder-262k
   - id: layer_24_width_16k_l0_big
     path: transcoder_all/layer_24_width_16k_l0_big
     l0: 120
@@ -18036,6 +18100,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_24_width_16k_l0_small_affine
     path: transcoder_all/layer_24_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/24-gemmascope-2-transcoder-16k
   - id: layer_24_width_262k_l0_big
     path: transcoder_all/layer_24_width_262k_l0_big
     l0: 120
@@ -18048,6 +18113,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_24_width_262k_l0_small_affine
     path: transcoder_all/layer_24_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/24-gemmascope-2-transcoder-262k
   - id: layer_25_width_16k_l0_big
     path: transcoder_all/layer_25_width_16k_l0_big
     l0: 120
@@ -18060,6 +18126,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_25_width_16k_l0_small_affine
     path: transcoder_all/layer_25_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/25-gemmascope-2-transcoder-16k
   - id: layer_25_width_262k_l0_big
     path: transcoder_all/layer_25_width_262k_l0_big
     l0: 120
@@ -18072,6 +18139,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_25_width_262k_l0_small_affine
     path: transcoder_all/layer_25_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/25-gemmascope-2-transcoder-262k
   - id: layer_2_width_16k_l0_big
     path: transcoder_all/layer_2_width_16k_l0_big
     l0: 73
@@ -18084,6 +18152,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_2_width_16k_l0_small_affine
     path: transcoder_all/layer_2_width_16k_l0_small_affine
     l0: 12
+    neuronpedia: gemma-3-1b-it/2-gemmascope-2-transcoder-16k
   - id: layer_2_width_262k_l0_big
     path: transcoder_all/layer_2_width_262k_l0_big
     l0: 73
@@ -18108,6 +18177,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_3_width_16k_l0_small_affine
     path: transcoder_all/layer_3_width_16k_l0_small_affine
     l0: 13
+    neuronpedia: gemma-3-1b-it/3-gemmascope-2-transcoder-16k
   - id: layer_3_width_262k_l0_big
     path: transcoder_all/layer_3_width_262k_l0_big
     l0: 80
@@ -18132,6 +18202,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_4_width_16k_l0_small_affine
     path: transcoder_all/layer_4_width_16k_l0_small_affine
     l0: 14
+    neuronpedia: gemma-3-1b-it/4-gemmascope-2-transcoder-16k
   - id: layer_4_width_262k_l0_big
     path: transcoder_all/layer_4_width_262k_l0_big
     l0: 87
@@ -18156,6 +18227,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_5_width_16k_l0_small_affine
     path: transcoder_all/layer_5_width_16k_l0_small_affine
     l0: 15
+    neuronpedia: gemma-3-1b-it/5-gemmascope-2-transcoder-16k
   - id: layer_5_width_262k_l0_big
     path: transcoder_all/layer_5_width_262k_l0_big
     l0: 94
@@ -18180,6 +18252,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_6_width_16k_l0_small_affine
     path: transcoder_all/layer_6_width_16k_l0_small_affine
     l0: 16
+    neuronpedia: gemma-3-1b-it/6-gemmascope-2-transcoder-16k
   - id: layer_6_width_262k_l0_big
     path: transcoder_all/layer_6_width_262k_l0_big
     l0: 101
@@ -18204,6 +18277,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_7_width_16k_l0_small_affine
     path: transcoder_all/layer_7_width_16k_l0_small_affine
     l0: 18
+    neuronpedia: gemma-3-1b-it/7-gemmascope-2-transcoder-16k
   - id: layer_7_width_262k_l0_big
     path: transcoder_all/layer_7_width_262k_l0_big
     l0: 108
@@ -18228,6 +18302,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_8_width_16k_l0_small_affine
     path: transcoder_all/layer_8_width_16k_l0_small_affine
     l0: 19
+    neuronpedia: gemma-3-1b-it/8-gemmascope-2-transcoder-16k
   - id: layer_8_width_262k_l0_big
     path: transcoder_all/layer_8_width_262k_l0_big
     l0: 115
@@ -18252,6 +18327,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_9_width_16k_l0_small_affine
     path: transcoder_all/layer_9_width_16k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/9-gemmascope-2-transcoder-16k
   - id: layer_9_width_262k_l0_big
     path: transcoder_all/layer_9_width_262k_l0_big
     l0: 120
@@ -19900,7 +19976,6 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_0_width_262k_l0_small_affine
     path: transcoder_all/layer_0_width_262k_l0_small_affine
     l0: 10
-  - id: layer_10_width_16k_l0_big
     path: transcoder_all/layer_10_width_16k_l0_big
     l0: 97
   - id: layer_10_width_16k_l0_big_affine
@@ -19924,7 +19999,6 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_10_width_262k_l0_small_affine
     path: transcoder_all/layer_10_width_262k_l0_small_affine
     l0: 16
-  - id: layer_11_width_16k_l0_big
     path: transcoder_all/layer_11_width_16k_l0_big
     l0: 101
   - id: layer_11_width_16k_l0_big_affine
@@ -19948,7 +20022,6 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_11_width_262k_l0_small_affine
     path: transcoder_all/layer_11_width_262k_l0_small_affine
     l0: 16
-  - id: layer_12_width_16k_l0_big
     path: transcoder_all/layer_12_width_16k_l0_big
     l0: 105
   - id: layer_12_width_16k_l0_big_affine
@@ -19972,7 +20045,6 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_12_width_262k_l0_small_affine
     path: transcoder_all/layer_12_width_262k_l0_small_affine
     l0: 17
-  - id: layer_13_width_16k_l0_big
     path: transcoder_all/layer_13_width_16k_l0_big
     l0: 108
   - id: layer_13_width_16k_l0_big_affine
@@ -19996,7 +20068,6 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_13_width_262k_l0_small_affine
     path: transcoder_all/layer_13_width_262k_l0_small_affine
     l0: 18
-  - id: layer_14_width_16k_l0_big
     path: transcoder_all/layer_14_width_16k_l0_big
     l0: 112
   - id: layer_14_width_16k_l0_big_affine
@@ -20020,7 +20091,6 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_14_width_262k_l0_small_affine
     path: transcoder_all/layer_14_width_262k_l0_small_affine
     l0: 18
-  - id: layer_15_width_16k_l0_big
     path: transcoder_all/layer_15_width_16k_l0_big
     l0: 116
   - id: layer_15_width_16k_l0_big_affine
@@ -20044,7 +20114,6 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_15_width_262k_l0_small_affine
     path: transcoder_all/layer_15_width_262k_l0_small_affine
     l0: 19
-  - id: layer_16_width_16k_l0_big
     path: transcoder_all/layer_16_width_16k_l0_big
     l0: 120
   - id: layer_16_width_16k_l0_big_affine
@@ -20068,7 +20137,6 @@ gemma-scope-2-12b-pt-transcoders-all:
   - id: layer_16_width_262k_l0_small_affine
     path: transcoder_all/layer_16_width_262k_l0_small_affine
     l0: 20
-  - id: layer_17_width_16k_l0_big
     path: transcoder_all/layer_17_width_16k_l0_big
     l0: 120
   - id: layer_17_width_16k_l0_big_affine

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -18165,6 +18165,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_2_width_262k_l0_small_affine
     path: transcoder_all/layer_2_width_262k_l0_small_affine
     l0: 12
+    neuronpedia: gemma-3-1b-it/2-gemmascope-2-transcoder-262k
   - id: layer_3_width_16k_l0_big
     path: transcoder_all/layer_3_width_16k_l0_big
     l0: 80
@@ -18190,6 +18191,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_3_width_262k_l0_small_affine
     path: transcoder_all/layer_3_width_262k_l0_small_affine
     l0: 13
+    neuronpedia: gemma-3-1b-it/3-gemmascope-2-transcoder-262k
   - id: layer_4_width_16k_l0_big
     path: transcoder_all/layer_4_width_16k_l0_big
     l0: 87
@@ -18215,6 +18217,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_4_width_262k_l0_small_affine
     path: transcoder_all/layer_4_width_262k_l0_small_affine
     l0: 14
+    neuronpedia: gemma-3-1b-it/4-gemmascope-2-transcoder-262k
   - id: layer_5_width_16k_l0_big
     path: transcoder_all/layer_5_width_16k_l0_big
     l0: 94
@@ -18240,6 +18243,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_5_width_262k_l0_small_affine
     path: transcoder_all/layer_5_width_262k_l0_small_affine
     l0: 15
+    neuronpedia: gemma-3-1b-it/5-gemmascope-2-transcoder-262k
   - id: layer_6_width_16k_l0_big
     path: transcoder_all/layer_6_width_16k_l0_big
     l0: 101
@@ -18265,6 +18269,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_6_width_262k_l0_small_affine
     path: transcoder_all/layer_6_width_262k_l0_small_affine
     l0: 16
+    neuronpedia: gemma-3-1b-it/6-gemmascope-2-transcoder-262k
   - id: layer_7_width_16k_l0_big
     path: transcoder_all/layer_7_width_16k_l0_big
     l0: 108
@@ -18290,6 +18295,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_7_width_262k_l0_small_affine
     path: transcoder_all/layer_7_width_262k_l0_small_affine
     l0: 18
+    neuronpedia: gemma-3-1b-it/7-gemmascope-2-transcoder-262k
   - id: layer_8_width_16k_l0_big
     path: transcoder_all/layer_8_width_16k_l0_big
     l0: 115
@@ -18315,6 +18321,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_8_width_262k_l0_small_affine
     path: transcoder_all/layer_8_width_262k_l0_small_affine
     l0: 19
+    neuronpedia: gemma-3-1b-it/8-gemmascope-2-transcoder-262k
   - id: layer_9_width_16k_l0_big
     path: transcoder_all/layer_9_width_16k_l0_big
     l0: 120
@@ -18340,6 +18347,7 @@ gemma-scope-2-1b-it-transcoders-all:
   - id: layer_9_width_262k_l0_small_affine
     path: transcoder_all/layer_9_width_262k_l0_small_affine
     l0: 20
+    neuronpedia: gemma-3-1b-it/9-gemmascope-2-transcoder-262k
 gemma-scope-2-1b-it-transcoders:
   conversion_func: gemma_3
   model: google/gemma-3-1b-it

--- a/sae_lens/saes/gated_sae.py
+++ b/sae_lens/saes/gated_sae.py
@@ -96,8 +96,8 @@ class GatedSAE(SAE[GatedSAEConfig]):
 
         # Gated-specific parameters need special handling
         # r_mag doesn't need scaling since W_enc scaling is sufficient for magnitude path
-        self.b_gate.data = self.b_gate.data * W_dec_norms
-        self.b_mag.data = self.b_mag.data * W_dec_norms
+        self.b_gate.data.mul_(W_dec_norms)
+        self.b_mag.data.mul_(W_dec_norms)
 
 
 @dataclass
@@ -228,8 +228,8 @@ class GatedTrainingSAE(TrainingSAE[GatedTrainingSAEConfig]):
 
         # Gated-specific parameters need special handling
         # r_mag doesn't need scaling since W_enc scaling is sufficient for magnitude path
-        self.b_gate.data = self.b_gate.data * W_dec_norms
-        self.b_mag.data = self.b_mag.data * W_dec_norms
+        self.b_gate.data.mul_(W_dec_norms)
+        self.b_mag.data.mul_(W_dec_norms)
 
 
 def _init_weights_gated(

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -519,14 +519,14 @@ class SAE(HookedRootModule, Generic[T_SAE_CONFIG], ABC):
 
     @torch.no_grad()
     def fold_and_get_W_dec_norm(self) -> torch.Tensor:
-        """Fold decoder norms into encoder and return them."""
+        """Fold decoder norms into encoder (in place, preserving parameter storage) and return them."""
         W_dec_norms = self.get_W_dec_norm()
-        self.W_dec.data = self.W_dec.data / W_dec_norms.unsqueeze(1)
-        self.W_enc.data = self.W_enc.data * W_dec_norms.unsqueeze(1).T
+        self.W_dec.data.div_(W_dec_norms.unsqueeze(1))
+        self.W_enc.data.mul_(W_dec_norms.unsqueeze(1).T)
 
         # Only update b_enc if it exists (standard/jumprelu architectures)
         if hasattr(self, "b_enc") and isinstance(self.b_enc, nn.Parameter):
-            self.b_enc.data = self.b_enc.data * W_dec_norms
+            self.b_enc.data.mul_(W_dec_norms)
 
         return W_dec_norms
 

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -627,7 +627,10 @@ class ActivationsStore:
         self.iterable_dataset = iter(self.dataset)
 
     def get_batch_tokens(
-        self, batch_size: int | None = None, raise_at_epoch_end: bool = False
+        self,
+        batch_size: int | None = None,
+        raise_at_epoch_end: bool = False,
+        move_to_model_device: bool = True,
     ):
         """
         Streams a batch of tokens from a dataset.
@@ -649,7 +652,10 @@ class ActivationsStore:
                     )
                 sequences.append(next(self.iterable_sequences))
 
-        return torch.stack(sequences, dim=0).to(_get_input_token_device(self.model))
+        batch_tokens = torch.stack(sequences, dim=0)
+        if move_to_model_device:
+            return batch_tokens.to(_get_input_token_device(self.model))
+        return batch_tokens
 
     @torch.no_grad()
     def get_activations(self, batch_tokens: torch.Tensor):

--- a/tests/saes/test_standard_sae.py
+++ b/tests/saes/test_standard_sae.py
@@ -19,6 +19,7 @@ from sae_lens.saes.standard_sae import (
 )
 from sae_lens.util import dtype_to_str
 from tests.helpers import (
+    ALL_FOLDABLE_ARCHITECTURES,
     assert_close,
     assert_not_close,
     build_runner_cfg,
@@ -696,3 +697,32 @@ def test_StandardSAE_forward_hooks():
     assert cache["hook_sae_acts_post"].equal(sae.encode(x))
     assert cache["hook_sae_recons"].equal(out)
     assert cache["hook_sae_output"].equal(out)
+
+
+@pytest.mark.parametrize("architecture", ALL_FOLDABLE_ARCHITECTURES)
+@torch.no_grad()
+def test_fold_W_dec_norm_keeps_parameter_storage_in_place(
+    architecture: str,
+):
+    cfg = build_sae_cfg_for_arch(architecture)
+    sae = SAE.from_dict(cfg.to_dict())
+    sae.turn_off_forward_pass_hook_z_reshaping()
+
+    for param in sae.parameters():
+        param.data = torch.rand_like(param)
+
+    w_dec_ptr = sae.W_dec.data.data_ptr()
+    w_enc_ptr = sae.W_enc.data.data_ptr()
+    b_enc_ptr = None
+    b_enc = getattr(sae, "b_enc", None)
+    if isinstance(b_enc, torch.nn.Parameter):
+        b_enc_ptr = b_enc.data.data_ptr()
+
+    sae.fold_W_dec_norm()
+
+    assert sae.W_dec.data.data_ptr() == w_dec_ptr
+    assert sae.W_enc.data.data_ptr() == w_enc_ptr
+    if b_enc_ptr is not None:
+        current_b_enc = getattr(sae, "b_enc", None)
+        assert isinstance(current_b_enc, torch.nn.Parameter)
+        assert current_b_enc.data.data_ptr() == b_enc_ptr

--- a/tests/training/test_activations_store.py
+++ b/tests/training/test_activations_store.py
@@ -379,6 +379,21 @@ def test_get_input_token_device_returns_input_embedding_device_when_sharded():
     assert next(proxy.parameters()).device == torch.device("cpu")
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No GPU to test on.")
+def test_get_batch_tokens_can_skip_model_device_transfer(ts_model: HookedTransformer):
+    cfg = build_runner_cfg(act_store_device="cpu", device="cuda:0")
+    activation_store = ActivationsStore.from_config(ts_model.to("cuda:0"), cfg)  # type: ignore
+
+    batch_on_model = activation_store.get_batch_tokens(batch_size=2)
+    batch_on_store = activation_store.get_batch_tokens(
+        batch_size=2,
+        move_to_model_device=False,
+    )
+
+    assert batch_on_model.device == torch.device("cuda:0")
+    assert batch_on_store.device == torch.device("cpu")
+
+
 def test_activations_store___iterate_tokenized_sequences__yields_concat_and_batched_sequences(
     ts_model: HookedTransformer,
 ):


### PR DESCRIPTION
> Thank you so much to the SAELens maintainers and community for making this foundationally valuable
> contribution to the open-source interpretability ecosystem! I'm using it extensively in the
> downstream world-model analysis framework I'm building (Interpretune) and couldn't appreciate your
> work more. The small seams proposed below come directly out of that heavy use.

## Overview

This PR carries the small SAELens surface that the coordinated **Scalable Dashboards** work depends
on: Neuronpedia source-set alias metadata for the gemma-scope-2 instruction-tuned transcoder
releases, a parameter-storage-preserving form of the decoder-norm fold, and an opt-in device seam on
`ActivationsStore.get_batch_tokens()`. SAELens plays a supporting role in the wave — the companion
PRs are SAEDashboard (columnar generation lane), neuronpedia (Python import utilities), and a
[coordination umbrella in interpretune](https://github.com/speediedan/interpretune/issues/231) linking the set (soft merge order: **SAELens → SAEDashboard →
neuronpedia**; nothing here hard-depends on the others).

> [!NOTE]
> **Ownership framing**: the upstream repos — principally Neuronpedia, together with SAEDashboard —
> own the core dashboard APIs and generation protocol and will continue to own them. Interpretune
> provides one example generation/import orchestration pipeline demonstrating the proposed
> scalability and example-aligned customizability. This PR does not redefine upstream interfaces or
> ownership.

## Key Changes

### 1. `pretrained_saes.yaml`: gemma-scope-2 Neuronpedia aliases + registry repair

Adds `neuronpedia:` aliases for the gemma-scope-2 instruction-tuned transcoder releases:

- `gemma-scope-2-4b-it-transcoders-all` `width_16k_l0_small_affine` → `gemma-3-4b-it/<layer>-gemmascope-2-transcoder-16k`
- `gemma-scope-2-1b-it-transcoders-all` `width_16k_l0_small_affine` → `gemma-3-1b-it/<layer>-gemmascope-2-transcoder-16k`
- `gemma-scope-2-1b-it-transcoders-all` `width_262k_l0_small_affine` → `gemma-3-1b-it/<layer>-gemmascope-2-transcoder-262k`

and repairs pre-existing structural damage in the `gemma-scope-2-12b-pt-transcoders-all`
`width_262k_l0_big` block (missing `- id:` keys), keeping the registry valid.

**Why**: the SAE rows already exist upstream, but Neuronpedia inference resolves source sets through
the `neuronpedia_id` alias metadata — without these aliases a local/hosted inference server cannot
translate e.g. `SAE_SETS=["gemmascope-2-transcoder-262k"]` into SAE ids for these releases (a
runtime registry probe returns `no_match`). SAELens is the single source of truth for this metadata;
synthesizing aliases in Neuronpedia's config layer was tried and reverted.

### 2. In-place `fold_W_dec_norm` (parameter-storage preservation)

`fold_and_get_W_dec_norm` (the shared helper from the "DRY fold decoder norms" refactor, #705) now
applies the fold with in-place `div_`/`mul_` on the existing parameter tensors instead of rebinding
`.data`; the gated-SAE `b_gate`/`b_mag` handling does the same. Numerics are unchanged (same clamp,
same order of operations).

**Why**: rebinding `.data` swaps the backing storage, silently invalidating external references held
by optimizers, hooks, or downstream tools that captured views of the parameters before folding —
SAEDashboard's runner is one such caller.

### 3. Activations-store device-transfer override

`ActivationsStore.get_batch_tokens()` gains an optional `move_to_model_device` argument (default
`True`, existing behavior unchanged), letting callers keep the stacked token batch on the
activations-store device; the seam is preserved across store refills.

**Why**: SAEDashboard's `NeuronpediaRunner.generate_tokens()` deduplicates and shuffles prompt
batches before model execution and calls `get_batch_tokens(move_to_model_device=False)` so staging
happens once, on the right device — downstream callers cannot request this cleanly against the
released surface without the seam.

## Compatibility / Testing

- Commit 1: runtime Neuronpedia-directory probes return the full expected layer counts per release
  (e.g. 26 `google/gemma-3-1b-it` rows for each aliased source set).
- Commit 2: new `test_fold_W_dec_norm_keeps_parameter_storage_in_place`, parametrized over all
  foldable architectures, pins `data_ptr()` stability for `W_dec`, `W_enc`, and `b_enc` (when
  present) across the fold; full `test_standard_sae.py` / `test_gated_sae.py` / `test_sae.py`
  suites pass.
- Commit 3: activations-store unit tests extended; 190 tests across the touched suites pass.
- Rebase note: upstream's fold-helper refactor (#705) landed between our fork point and the rebase —
  the in-place change is expressed inside the upstream helper structure (not a parallel
  implementation) and the storage test sits alongside upstream's relocated fold tests.
- Downstream validation: these three seams have run under the Scalable Dashboards production +
  benchmark workloads (26-layer gemma-3-1b-it 262k-transcoder dashboard generation; three-way parity
  suite) for several weeks — [evidence package](https://github.com/speediedan/interpretune/blob/streamlined-streamable-dashboard-generation-phase-1/docs/benchmark_artifacts/full_20260727/benchmark_summary.md) linked from the [coordination umbrella](https://github.com/speediedan/interpretune/issues/231).

## Coordination

Part of the coordinated upstream **Scalable Dashboards** PR set (Wave 1): SAEDashboard (columnar
generation lane), neuronpedia (import utilities + ecosystem overview), circuit-tracer#79 (existing),
with the [coordination umbrella in interpretune](https://github.com/speediedan/interpretune/issues/231) hosting the reproduction quickstart, benchmark
evidence, and the Wave 1/Wave 2 roadmap. Soft merge order SAELens → SAEDashboard → neuronpedia
(SAELens first unblocks the neuronpedia inference pin flip to a released SAELens floor).
@chanind 


---

## Verifying this PR yourself

Runner: `make test` = `poetry run pytest -v --cov=sae_lens/ tests`.

| Claim | Verify it | Cost |
| --- | --- | --- |
| In-place fold preserves parameter storage | `poetry run pytest tests/saes/test_standard_sae.py::test_fold_W_dec_norm_keeps_parameter_storage_in_place` → 3 passed (parametrized over standard/gated/jumprelu; asserts `data_ptr()` stability) | seconds, CPU, offline |
| No fold regressions | `poetry run pytest tests/saes/test_standard_sae.py tests/saes/test_gated_sae.py tests/saes/test_jumprelu_sae.py -k fold` → 11 passed | seconds |
| `move_to_model_device` seam | `poetry run pytest tests/training/test_activations_store.py::test_get_batch_tokens_can_skip_model_device_transfer` — **CUDA-gated; silently skips on CPU-only machines** | seconds, GPU |
| Surrounding activations-store behavior | `poetry run pytest tests/training/test_activations_store.py -k "get_batch_tokens or input_token_device"` → 10 passed | seconds |
| Alias metadata resolves | the snippet below, offline (`HF_HUB_OFFLINE=1`), no auth or gated weights needed | seconds |

```python
from collections import Counter
from sae_lens.loading.pretrained_saes_directory import get_pretrained_saes_directory

rows = [np_id for _, lookup in get_pretrained_saes_directory().items()
        for np_id in lookup.neuronpedia_id.values()
        if np_id and np_id.startswith("gemma-3-1b-it/")]
print(Counter(n.split("/", 1)[1].split("-", 1)[1] for n in rows))
```

Expected: **26** rows for `gemma-3-1b-it/gemmascope-2-transcoder-16k` and **18** for `-262k`. The
diff agrees exactly — 78 `neuronpedia:` lines added, 0 removed (26 for 1b-it-16k, 18 for 1b-it-262k,
34 for 4b-it-16k).

Reproducing the benchmark, and running the example notebook that consumes locally generated
dashboards, are documented once for the whole wave here:
**[Verifying dashboard generation](https://interpretune.readthedocs.io/en/latest/usage/verifying_dashboard_generation.html)**.
Cross-PR review order and the shared caveats live on the umbrella issue,
[interpretune#231](https://github.com/speediedan/interpretune/issues/231).
