### PR TITLE
fix: remove the unused GradScaler from SAETrainer

### DIFF
--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -131,12 +131,9 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
                 final_value=coeff_cfg.value,
             )
 
-        # Setup autocast if using. autocast/GradScaler want the device *type*
-        # (e.g. "cuda"), not a fully qualified device string like "cuda:1".
+        # Setup autocast if using. autocast wants the device *type* (e.g. "cuda"),
+        # not a fully qualified device string like "cuda:1".
         device_type = torch.device(self.cfg.device).type
-        self.grad_scaler = torch.amp.GradScaler(
-            device=device_type, enabled=self.cfg.autocast
-        )
 
         if self.cfg.autocast:
             self.autocast_if_enabled = torch.autocast(
@@ -360,17 +357,10 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
                 self.act_freq_scores += firing_feats.sum(0)
                 self.n_frac_active_samples += self.cfg.train_batch_size_samples
 
-        # Grad scaler will rescale gradients if autocast is enabled
-        self.grad_scaler.scale(
-            train_step_output.loss
-        ).backward()  # loss.backward() if not autocasting
-        self.grad_scaler.unscale_(self.optimizer)  # needed to clip correctly
+        train_step_output.loss.backward()
         # TODO: Work out if grad norm clipping should be in config / how to test it.
         torch.nn.utils.clip_grad_norm_(sae.parameters(), 1.0)
-        self.grad_scaler.step(
-            self.optimizer
-        )  # just ctx.optimizer.step() if not autocasting
-        self.grad_scaler.update()
+        self.optimizer.step()
 
         self.optimizer.zero_grad()
         self.lr_scheduler.step()

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -31,6 +31,7 @@ from sae_lens.training.sae_trainer import (
 from tests.helpers import (
     TINYSTORIES_MODEL,
     assert_close,
+    assert_not_close,
     build_runner_cfg,
     build_sae_training_cfg,
     load_model_cached,
@@ -762,3 +763,31 @@ def test_sae_trainer_fit_logs_train_eval_and_sparsity_metrics_to_wandb(
     assert "model_performance_preservation" in all_keys
     # the feature_sampling_window=2 sparsity reset emits its own log dict
     assert "metrics/mean_log10_feature_sparsity" in all_keys
+
+
+@pytest.mark.parametrize("autocast", [True, False])
+def test_train_step_updates_params_and_reduces_loss_with_autocast(
+    autocast: bool,
+) -> None:
+    d_in, d_sae, batch_size = 8, 16, 32
+    sae = StandardTrainingSAE(build_sae_training_cfg(d_in=d_in, d_sae=d_sae))
+    trainer = SAETrainer(
+        cfg=SAETrainerConfig(
+            total_training_samples=batch_size,
+            train_batch_size_samples=batch_size,
+            lr_end=1e-4,
+            autocast=autocast,
+        ),
+        sae=sae,
+        data_provider=iter(lambda: torch.randn(batch_size, d_in), None),
+    )
+    before = sae.W_enc.detach().clone()
+
+    acts = torch.randn(batch_size, d_in)
+    losses = [
+        trainer._train_step(sae=sae, sae_in=acts).loss.item()  # noqa: SLF001
+        for _ in range(5)
+    ]
+
+    assert losses[-1] < losses[0]
+    assert_not_close(sae.W_enc.detach(), before)


### PR DESCRIPTION
## Summary

`SAETrainer` constructs a `torch.amp.GradScaler` and routes every training step through `scale` / `unscale_` / `step` / `update`. It has never had anything to do, and in one configuration it makes training impossible.

`GradScaler` solves exactly one problem: **fp16 gradient underflow**. fp16's smallest normal value is `6.10e-05`, so small gradients flush to zero and loss scaling is needed to lift them into range. SAELens never autocasts to fp16 — all three autocast sites hardcode bfloat16 (`sae_trainer.py`, and two in `activations_store.py`), and bfloat16 has the *same exponent range as fp32*:

| dtype | min normal | max | eps |
|---|---|---|---|
| float16 | 6.10e-05 | 6.55e+04 | 9.8e-04 |
| bfloat16 | **1.18e-38** | 3.39e+38 | 7.8e-03 |
| float32 | 1.18e-38 | 3.40e+38 | 1.2e-07 |

bfloat16 trades mantissa bits for range, not range for precision. Nothing underflows, so there is nothing to scale.

## Why this isn't just dead code

1. It adds a scale, an unscale and an inf/nan check to **every** training step.
2. It can **silently skip optimizer steps** when its inf check trips — an invisible way for training to stall.
3. With `autocast=True` on an SAE holding bfloat16 parameters it raises:

```
NotImplementedError: "_amp_foreach_non_finite_check_and_unscale_cuda" not implemented for 'BFloat16'
```

making that configuration untrainable on GPU. This was found by a real training run dying at startup.

## Changes

- Remove the `GradScaler` and call `loss.backward()` / `optimizer.step()` directly. Gradient clipping is unaffected — it no longer needs an explicit unscale first.
- Add the first test covering trainer-level `autocast`. Only `autocast_lm` was tested, which is why this went unnoticed.

## Notes for reviewers

- `grad_scaler` was confined to `sae_trainer.py`; no checkpoint state, docs, or other callers reference it, so nothing else needs updating. (`tests/_comparison/sae_lens_old/` has its own vendored copy, deliberately untouched.)
- **The crash is CUDA-only.** I verified that bfloat16 gradients pass through `GradScaler` fine on CPU, so a CPU regression test would pass with or without this change. Rather than add a test that implies coverage it doesn't have, the new test checks that autocast training updates parameters and reduces loss, in both autocast modes.
- If fp16 autocast is ever added, the scaler should come back gated on the autocast dtype (`enabled = autocast and autocast_dtype is torch.float16`) rather than on `cfg.autocast`.

`pytest tests/training tests/saes`: 552 passed, 6 skipped. ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)