### PR TITLE
fix: treat a BOS token id of 0 as set when concatenation is disabled

### DIFF
--- a/sae_lens/tokenization_and_batching.py
+++ b/sae_lens/tokenization_and_batching.py
@@ -82,7 +82,7 @@ def concat_and_batch_sequences(
         max_batches: If not provided, the iterator will be run to completion.
     """
     if disable_concat_sequences:
-        if begin_batch_token_id and not begin_sequence_token_id:
+        if begin_batch_token_id is not None and begin_sequence_token_id is None:
             begin_sequence_token_id = begin_batch_token_id
         for sequence in tokens_iterator:
             if (

--- a/tests/training/test_tokenization_and_batching.py
+++ b/tests/training/test_tokenization_and_batching.py
@@ -533,3 +533,43 @@ def test_tokenize_with_chat_template_produces_correct_tokens():
     assert "Hello" in decoded
     assert "<|assistant|>" in decoded
     assert "Hi" in decoded
+
+
+def test_concat_and_batch_sequences_uses_begin_batch_token_id_of_zero_with_concat_sequences_disabled():
+    # Token id 0 is a valid BOS id, e.g. <|endoftext|> on GPT-NeoX and Pythia
+    all_toks = torch.arange(1, 20)
+    seqs = [all_toks[:3], all_toks[3:10], all_toks[10:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+            begin_batch_token_id=0,
+            disable_concat_sequences=True,
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [0, 4, 5, 6, 7],
+        [0, 11, 12, 13, 14],
+    ]
+    assert batches.tolist() == expected
+
+
+def test_concat_and_batch_sequences_keeps_explicit_begin_sequence_token_id_of_zero():
+    all_toks = torch.arange(1, 20)
+    seqs = [all_toks[:3], all_toks[3:10], all_toks[10:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+            begin_batch_token_id=999,
+            begin_sequence_token_id=0,
+            disable_concat_sequences=True,
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [0, 4, 5, 6, 7],
+        [0, 11, 12, 13, 14],
+    ]
+    assert batches.tolist() == expected


### PR DESCRIPTION
# Summary:

`concat_and_batch_sequences` carries the batch-start token into the `disable_concat_sequences` path with a truthiness test, while every other token-id check in the file uses `is not None`:

```python
if begin_batch_token_id and not begin_sequence_token_id:
    begin_sequence_token_id = begin_batch_token_id
```

Token id `0` is the BOS id of the GPT-NeoX family, including Pythia, so it reads as absent. Two things follow: a requested BOS of `0` is never prepended, and an explicit `begin_sequence_token_id=0` is silently replaced by `begin_batch_token_id`.

This reaches training, beyond just pretokenization. `ActivationsStore._iterate_tokenized_sequences` passes `begin_batch_token_id=(bos_token_id if self.prepend_bos else None)` with `begin_sequence_token_id=None`, and `prepend_bos` defaults to `True`. So a SAE trained on Pythia with `disable_concat_sequences=True` gets activations with no BOS while the config records that BOS was prepended, with no warning.

```diff
-        if begin_batch_token_id and not begin_sequence_token_id:
+        if begin_batch_token_id is not None and begin_sequence_token_id is None:
```

The path is well covered, but every existing `disable_concat_sequences` test uses id `998` or `999`, so the one value that breaks the line was never exercised. I added two tests using `0`, one per failure mode. Both fail on `main`.

Existing runs that hit this now get the BOS they asked for, so their sequences shift by one token and drop the last token of each context, which is what the non-zero-BOS path already does. Nothing changes for gpt2 style tokenizers, and `disable_concat_sequences` defaults to `False`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)