### PR TITLE
Fix SkipTranscoder parameter dtype and device

### DIFF
--- a/sae_lens/saes/transcoder.py
+++ b/sae_lens/saes/transcoder.py
@@ -228,7 +228,14 @@ class SkipTranscoder(Transcoder):
 
         # Initialize skip connection matrix
         # Shape: [d_out, d_in] to map from input to output dimension
-        self.W_skip = nn.Parameter(torch.zeros(self.cfg.d_out, self.cfg.d_in))
+        self.W_skip = nn.Parameter(
+            torch.zeros(
+                self.cfg.d_out,
+                self.cfg.d_in,
+                dtype=self.dtype,
+                device=self.device,
+            )
+        )
 
     @override
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/tests/saes/test_transcoder.py
+++ b/tests/saes/test_transcoder.py
@@ -322,6 +322,15 @@ class TestSkipTranscoder:
         # W_skip should be initialized to zeros
         assert torch.all(transcoder.W_skip == 0)
 
+    def test_skip_transcoder_initializes_w_skip_with_configured_dtype(self):
+        cfg = build_skip_transcoder_cfg(dtype="float64", device="cpu")
+
+        transcoder = SkipTranscoder(cfg)
+
+        assert transcoder.W_skip.dtype == torch.float64
+        assert transcoder.W_skip.device.type == "cpu"
+        transcoder(torch.randn(2, cfg.d_in, dtype=torch.float64))
+
     def test_skip_transcoder_forward_with_zero_skip(self):
         """With W_skip=0, output should match base Transcoder."""
         cfg = build_skip_transcoder_cfg(d_in=32, d_sae=64, d_out=48)


### PR DESCRIPTION
## Problem

`SkipTranscoder` initializes `W_skip` with a bare `torch.zeros` call. This leaves the parameter on CPU with the default dtype even when the transcoder is configured for another dtype or device. A float64 configuration then fails during the forward pass because the skip projection mixes float64 activations with a float32 parameter.

## Fix

Initialize `W_skip` with the transcoder's configured dtype and device, matching the other parameters. Add a regression that constructs a float64 transcoder, checks the parameter metadata, and runs a forward pass.

## Test

- `pytest tests/saes/test_transcoder.py` (52 passed)
- Ruff lint and format checks on the changed files
- `git diff --check`

## Risk

Low. The change only affects initial placement of the zero-initialized skip parameter; its shape and initial values are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing focused tests pass locally
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility