### PR TITLE
fix checkpoint ID generation with current W&B

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -1,9 +1,10 @@
 import json
 import math
+import uuid
 import warnings
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 import simple_parsing
 import torch
@@ -355,11 +356,7 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         if self.lr_end is None:
             self.lr_end = self.lr / 10
 
-        unique_id = self.logger.wandb_id
-        if unique_id is None:
-            unique_id = cast(
-                Any, wandb
-            ).util.generate_id()  # not sure why this type is erroring
+        unique_id = self.logger.wandb_id or uuid.uuid4().hex[:8]
         self.checkpoint_path = f"{self.checkpoint_path}/{unique_id}"
 
         if self.verbose:

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -171,6 +171,20 @@ def test_LanguageModelSAERunnerConfig_accepts_zero_prefetch_llm_batches():
     assert cfg.prefetch_llm_batches == 0
 
 
+def test_LanguageModelSAERunnerConfig_generates_checkpoint_id_without_wandb_util(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake_uuid = type("UUID", (), {"hex": "12345678abcdef"})()
+    monkeypatch.setattr("sae_lens.config.uuid.uuid4", lambda: fake_uuid)
+
+    cfg = LanguageModelSAERunnerConfig(
+        sae=StandardTrainingSAEConfig(d_in=5, d_sae=10),
+        checkpoint_path="checkpoints",
+    )
+
+    assert cfg.checkpoint_path == "checkpoints/12345678"
+
+
 def test_LanguageModelSAERunnerConfig_to_dict_and_from_dict():
     cfg = LanguageModelSAERunnerConfig(
         sae=JumpReLUTrainingSAEConfig(


### PR DESCRIPTION
## Summary

- replace the removed private `wandb.util.generate_id` helper with `uuid.uuid4`
- preserve the existing eight-character checkpoint ID format
- add a deterministic checkpoint-path regression

The current dependency range resolves W&B 0.28.2, where `wandb.util.generate_id` is no longer available. This currently breaks config construction across the test suite before unrelated tests can run.

## Validation

- `pytest -q tests/training/test_config.py` — 30 passed
- `ruff check sae_lens/config.py tests/training/test_config.py`
- `ruff format --check sae_lens/config.py tests/training/test_config.py`
- `git diff --check`

Risk is limited to the source of auto-generated run IDs; explicit `wandb_id` values and the checkpoint path shape are unchanged.