### PR TITLE
Validate empty Matryoshka level widths

### DIFF
--- a/sae_lens/saes/matryoshka_batchtopk_sae.py
+++ b/sae_lens/saes/matryoshka_batchtopk_sae.py
@@ -203,6 +203,9 @@ class MatryoshkaBatchTopKTrainingSAE(BatchTopKTrainingSAE):
 
 
 def _validate_matryoshka_config(cfg: MatryoshkaBatchTopKTrainingSAEConfig) -> None:
+    if not cfg.matryoshka_widths:
+        raise ValueError("cfg.matryoshka_widths must not be empty.")
+
     if cfg.matryoshka_widths[-1] != cfg.d_sae:
         # warn the users that we will add a final matryoshka level
         warnings.warn(

--- a/tests/saes/test_matryoshka_batchtopk_sae.py
+++ b/tests/saes/test_matryoshka_batchtopk_sae.py
@@ -48,6 +48,16 @@ def test_validate_matryoshka_config_appends_d_sae_if_missing():
     assert cfg.matryoshka_widths == [5, 10, 20]
 
 
+def test_validate_matryoshka_config_raises_if_widths_are_empty():
+    cfg = build_matryoshka_batchtopk_sae_training_cfg(
+        d_sae=20,
+        k=5,
+        matryoshka_widths=[],
+    )
+    with pytest.raises(ValueError, match="must not be empty"):
+        _validate_matryoshka_config(cfg)
+
+
 def test_validate_matryoshka_config_does_not_append_d_sae_if_already_present():
     cfg = build_matryoshka_batchtopk_sae_training_cfg(
         d_sae=20,


### PR DESCRIPTION
## Problem

`MatryoshkaBatchTopKTrainingSAEConfig` defaults `matryoshka_widths` to an empty list, but `_validate_matryoshka_config` immediately indexes its final element. Omitting the hierarchy therefore raises an opaque `IndexError` instead of a configuration error.

## Fix

Reject an empty width list with a descriptive `ValueError` before inspecting the final level, and add a direct regression test using the real training config.

## Test

- `pytest tests/saes/test_matryoshka_batchtopk_sae.py -q` — 25 passed (with the separately isolated W&B compatibility prerequisite needed by the current resolved environment)
- `ruff check` and `ruff format --check` on both changed files
- `git diff --check`

## Risk

Low. Valid non-empty configurations are unchanged; only the exception type and message for an already-invalid empty hierarchy change.