### PR TITLE
feat: add jumprelu_ste_to_input, and keep the JumpReLU threshold in float32

### DIFF
--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -260,11 +260,13 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         # We'll store a bandwidth for the training approach, if needed
         self.bandwidth = cfg.jumprelu_bandwidth
 
+        # Kept in float32 whatever the SAE dtype, since Adam's ~lr sized steps on an
+        # O(1) threshold round away in bfloat16; cast to the compute dtype at use.
         self.threshold = nn.Parameter(
             torch.full(
                 (self.cfg.d_sae,),
                 cfg.jumprelu_init_threshold,
-                dtype=self.dtype,
+                dtype=torch.float32,
                 device=self.device,
             )
         )
@@ -300,7 +302,7 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         feature_acts = self.hook_sae_acts_post(
             JumpReLU.apply(
                 hidden_pre,
-                self.threshold,
+                self.threshold.to(hidden_pre.dtype),
                 self.bandwidth,
                 self.cfg.jumprelu_ste_to_input,
             )
@@ -318,7 +320,7 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
     ) -> dict[str, torch.Tensor]:
         """Calculate architecture-specific auxiliary loss terms."""
 
-        threshold = self.threshold
+        threshold = self.threshold.to(hidden_pre.dtype)
         W_dec_norm = self.W_dec.norm(dim=1)
         if self.cfg.jumprelu_sparsity_loss_mode == "step":
             l0 = torch.sum(

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -283,6 +283,16 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         )
 
     @override
+    def _apply(self, *args: Any, **kwargs: Any) -> "JumpReLUTrainingSAE":
+        out = super()._apply(*args, **kwargs)
+        # nn.Module.to() casts every float parameter, and the load paths call it
+        # with cfg.dtype, so restore the threshold invariant from __init__.
+        threshold = self._parameters.get("threshold")
+        if threshold is not None and threshold.dtype != torch.float32:
+            threshold.data = threshold.data.float()
+        return out
+
+    @override
     def training_forward_pass(self, step_input: TrainStepInput) -> TrainStepOutput:
         # Keep the threshold non-negative; below zero the gate passes negative
         # pre-activations through. Projected on .data rather than clamped in the

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -26,29 +26,34 @@ class Step(torch.autograd.Function):
         x: torch.Tensor,
         threshold: torch.Tensor,
         bandwidth: float,  # noqa: ARG004
+        ste_to_input: bool,  # noqa: ARG004
     ) -> torch.Tensor:
         return (x > threshold).to(x)
 
     @staticmethod
     def setup_context(
-        ctx: Any, inputs: tuple[torch.Tensor, torch.Tensor, float], output: torch.Tensor
+        ctx: Any,
+        inputs: tuple[torch.Tensor, torch.Tensor, float, bool],
+        output: torch.Tensor,
     ) -> None:
-        x, threshold, bandwidth = inputs
+        x, threshold, bandwidth, ste_to_input = inputs
         del output
         ctx.save_for_backward(x, threshold)
         ctx.bandwidth = bandwidth
+        ctx.ste_to_input = ste_to_input
 
     @staticmethod
     def backward(  # type: ignore[override]
         ctx: Any, grad_output: torch.Tensor
-    ) -> tuple[None, torch.Tensor, None]:
+    ) -> tuple[torch.Tensor | None, torch.Tensor, None, None]:
         x, threshold = ctx.saved_tensors
         bandwidth = ctx.bandwidth
-        threshold_grad = torch.sum(
-            -(1.0 / bandwidth) * rectangle((x - threshold) / bandwidth) * grad_output,
-            dim=0,
-        )
-        return None, threshold_grad, None
+        ste = (1.0 / bandwidth) * rectangle((x - threshold) / bandwidth) * grad_output
+        threshold_grad = torch.sum(-ste, dim=0)
+        # the step function depends on x only through (x - threshold), so the
+        # estimator's gradient wrt x is the negation of its gradient wrt threshold
+        x_grad = ste if ctx.ste_to_input else None
+        return x_grad, threshold_grad, None, None
 
 
 class JumpReLU(torch.autograd.Function):
@@ -57,32 +62,38 @@ class JumpReLU(torch.autograd.Function):
         x: torch.Tensor,
         threshold: torch.Tensor,
         bandwidth: float,  # noqa: ARG004
+        ste_to_input: bool,  # noqa: ARG004
     ) -> torch.Tensor:
         return (x * (x > threshold)).to(x)
 
     @staticmethod
     def setup_context(
-        ctx: Any, inputs: tuple[torch.Tensor, torch.Tensor, float], output: torch.Tensor
+        ctx: Any,
+        inputs: tuple[torch.Tensor, torch.Tensor, float, bool],
+        output: torch.Tensor,
     ) -> None:
-        x, threshold, bandwidth = inputs
+        x, threshold, bandwidth, ste_to_input = inputs
         del output
         ctx.save_for_backward(x, threshold)
         ctx.bandwidth = bandwidth
+        ctx.ste_to_input = ste_to_input
 
     @staticmethod
     def backward(  # type: ignore[override]
         ctx: Any, grad_output: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor, None]:
+    ) -> tuple[torch.Tensor, torch.Tensor, None, None]:
         x, threshold = ctx.saved_tensors
         bandwidth = ctx.bandwidth
-        x_grad = (x > threshold) * grad_output  # We don't apply STE to x input
-        threshold_grad = torch.sum(
-            -(threshold / bandwidth)
+        ste = (
+            (threshold / bandwidth)
             * rectangle((x - threshold) / bandwidth)
-            * grad_output,
-            dim=0,
+            * grad_output
         )
-        return x_grad, threshold_grad, None
+        threshold_grad = torch.sum(-ste, dim=0)
+        x_grad = (x > threshold) * grad_output
+        if ctx.ste_to_input:
+            x_grad = x_grad + ste
+        return x_grad, threshold_grad, None, None
 
 
 @dataclass
@@ -192,6 +203,7 @@ class JumpReLUTrainingSAEConfig(TrainingSAEConfig):
         l0_warm_up_steps: number of warm-up steps for the l0 sparsity loss
         pre_act_loss_coefficient: coefficient for the pre-activation loss. Set to None to disable. Set to 3e-6 to match Anthropic's setup.
         jumprelu_tanh_scale: scale for the tanh sparsity loss. Only relevant for "tanh" sparsity loss mode.
+        jumprelu_ste_to_input: whether the straight-through estimator also passes gradient to the pre-activations, and so to the encoder, rather than to the threshold alone. False matches DeepMind's JumpReLU, True matches Anthropic's setup.
     """
 
     jumprelu_init_threshold: float = 0.01
@@ -206,6 +218,9 @@ class JumpReLUTrainingSAEConfig(TrainingSAEConfig):
 
     # only relevant for tanh sparsity loss mode
     jumprelu_tanh_scale: float = 4.0
+
+    # Anthropic passes the STE gradient to all model params, DeepMind only to the threshold
+    jumprelu_ste_to_input: bool = False
 
     @override
     @classmethod
@@ -283,7 +298,12 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
 
         hidden_pre = self.hook_sae_acts_pre(sae_in @ self.W_enc + self.b_enc)
         feature_acts = self.hook_sae_acts_post(
-            JumpReLU.apply(hidden_pre, self.threshold, self.bandwidth)
+            JumpReLU.apply(
+                hidden_pre,
+                self.threshold,
+                self.bandwidth,
+                self.cfg.jumprelu_ste_to_input,
+            )
         )
 
         return feature_acts, hidden_pre  # type: ignore
@@ -302,7 +322,12 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         W_dec_norm = self.W_dec.norm(dim=1)
         if self.cfg.jumprelu_sparsity_loss_mode == "step":
             l0 = torch.sum(
-                Step.apply(hidden_pre, threshold, self.bandwidth),  # type: ignore
+                Step.apply(  # type: ignore
+                    hidden_pre,
+                    threshold,
+                    self.bandwidth,
+                    self.cfg.jumprelu_ste_to_input,
+                ),
                 dim=-1,
             )
             l0_loss = (step_input.coefficients["l0"] * l0).mean()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -143,6 +143,7 @@ class TrainingSAEConfigDict(TypedDict, total=False):
     topk_threshold_lr: float  # For BatchTopK
     jumprelu_sparsity_loss_mode: Literal["step", "tanh"]  # For JumpReLU
     jumprelu_tanh_scale: float  # For JumpReLU
+    jumprelu_ste_to_input: bool  # For JumpReLU
     rescale_acts_by_decoder_norm: bool  # For TopK
     matryoshka_widths: list[int]  # For MatryoshkaBatchTopK
     residual_threshold: float  # for MatchingPursuitSAE
@@ -347,6 +348,7 @@ def build_jumprelu_runner_cfg(
         "decoder_init_norm": 0.1,
         "jumprelu_sparsity_loss_mode": "step",
         "jumprelu_tanh_scale": 4.0,
+        "jumprelu_ste_to_input": False,
         "jumprelu_init_threshold": 0.001,
         "jumprelu_bandwidth": 0.001,
         "l0_coefficient": 0.3,

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -13,7 +13,7 @@ from sae_lens.saes.jumprelu_sae import (
     JumpReLUTrainingSAE,
     calculate_pre_act_loss,
 )
-from sae_lens.saes.sae import SAE, TrainStepInput
+from sae_lens.saes.sae import SAE, TrainingSAE, TrainStepInput
 from tests.helpers import (
     assert_close,
     assert_not_close,
@@ -608,3 +608,19 @@ def test_JumpReLUTrainingSAE_keeps_threshold_in_float32_for_bfloat16_saes():
     # most of the lr-sized steps and barely move
     moved = abs(sae.threshold.detach().float().mean().item() - init)
     assert moved > 20 * lr
+
+
+def test_JumpReLUTrainingSAE_keeps_threshold_in_float32_across_a_disk_roundtrip(
+    tmp_path: Path,
+) -> None:
+    sae = JumpReLUTrainingSAE(
+        build_jumprelu_sae_training_cfg(dtype="bfloat16", jumprelu_init_threshold=1.1)
+    )
+    sae.save_model(str(tmp_path))
+
+    loaded = TrainingSAE.load_from_disk(tmp_path, device="cpu")
+
+    # load_from_disk ends in sae.to(dtype=cfg.dtype), which would otherwise
+    # downcast the threshold and silently undo the guard
+    assert loaded.W_enc.dtype == torch.bfloat16
+    assert loaded.threshold.dtype == torch.float32

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -40,7 +40,7 @@ def test_JumpReLUTrainingSAE_encoding():
     sae_in = sae.process_sae_in(x)
     expected_hidden_pre = sae_in @ sae.W_enc + sae.b_enc
     expected_feature_acts = JumpReLU.apply(
-        expected_hidden_pre, sae.threshold, sae.bandwidth
+        expected_hidden_pre, sae.threshold, sae.bandwidth, False
     )
 
     assert_close(feature_acts, expected_feature_acts, atol=1e-6)  # type: ignore
@@ -521,3 +521,52 @@ def test_JumpReLUTrainingSAE_errors_on_invalid_sparsity_loss_mode():
                 is_logging_step=False,
             ),
         )
+
+
+@pytest.mark.parametrize("ste_to_input", [True, False])
+def test_JumpReLU_ste_to_input_matches_the_analytic_gradient(ste_to_input: bool):
+    bandwidth = 0.5
+    threshold = torch.full((4,), 1.0, requires_grad=True)
+    # one pre-activation per case: below the window, inside it, above the threshold
+    x = torch.tensor([[0.0, 0.9, 1.05, 3.0]], requires_grad=True)
+
+    out = JumpReLU.apply(x, threshold, bandwidth, ste_to_input)
+    out.sum().backward()  # type: ignore
+    assert x.grad is not None and threshold.grad is not None
+
+    in_window = ((x - threshold).abs() < bandwidth / 2).float()
+    ste = threshold / bandwidth * in_window
+    expected_x_grad = (x > threshold).float() + (ste if ste_to_input else 0.0)
+
+    assert_close(x.grad, expected_x_grad, atol=1e-6)
+    # the threshold gradient is unaffected by where the estimator is routed
+    assert_close(threshold.grad, -ste.squeeze(0), atol=1e-6)
+
+
+def test_JumpReLUTrainingSAE_ste_to_input_reaches_the_encoder_for_gated_off_latents():
+    x = torch.ones(1, 2)
+
+    def encoder_grad(ste_to_input: bool) -> torch.Tensor:
+        sae = JumpReLUTrainingSAE(
+            build_jumprelu_sae_training_cfg(
+                d_in=2,
+                d_sae=2,
+                jumprelu_bandwidth=1.0,
+                jumprelu_init_threshold=1.0,
+                jumprelu_ste_to_input=ste_to_input,
+            )
+        )
+        # pre-activations of 0.8 sit below the threshold of 1.0 but inside the
+        # estimator's window of (0.5, 1.5), so nothing fires and any encoder
+        # gradient can only have arrived through the estimator
+        sae.W_enc.data = 0.8 * torch.eye(2)
+        sae.b_enc.data = torch.zeros(2)
+        feature_acts, _ = sae.encode_with_hidden_pre(x)
+        assert (feature_acts == 0).all()
+        feature_acts.sum().backward()
+        assert sae.W_enc.grad is not None
+        return sae.W_enc.grad
+
+    # estimator value is threshold / bandwidth = 1.0, and x is all ones
+    assert_close(encoder_grad(ste_to_input=True), torch.ones(2, 2), atol=1e-6)
+    assert_close(encoder_grad(ste_to_input=False), torch.zeros(2, 2), atol=1e-6)

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -624,3 +624,49 @@ def test_JumpReLUTrainingSAE_keeps_threshold_in_float32_across_a_disk_roundtrip(
     # downcast the threshold and silently undo the guard
     assert loaded.W_enc.dtype == torch.bfloat16
     assert loaded.threshold.dtype == torch.float32
+
+
+def test_JumpReLUTrainingSAE_ste_to_input_routes_the_step_l0_loss_to_the_encoder():
+    x = torch.ones(1, 2)
+
+    def encoder_grad(ste_to_input: bool) -> torch.Tensor:
+        sae = JumpReLUTrainingSAE(
+            build_jumprelu_sae_training_cfg(
+                d_in=2,
+                d_sae=2,
+                jumprelu_sparsity_loss_mode="step",
+                jumprelu_bandwidth=1.0,
+                jumprelu_init_threshold=1.0,
+                jumprelu_ste_to_input=ste_to_input,
+            )
+        )
+        # pre-activations of 0.8 are below the threshold of 1.0 but inside the
+        # estimator's window of (0.5, 1.5), so nothing fires and the L0 loss is
+        # the only term that can reach the encoder
+        sae.W_enc.data = 0.8 * torch.eye(2)
+        sae.b_enc.data = torch.zeros(2)
+        feature_acts, hidden_pre = sae.encode_with_hidden_pre(x)
+        assert (feature_acts == 0).all()
+
+        losses = sae.calculate_aux_loss(
+            step_input=TrainStepInput(
+                sae_in=x,
+                coefficients={"l0": 1.0},
+                dead_neuron_mask=None,
+                n_training_steps=0,
+                is_logging_step=False,
+            ),
+            feature_acts=feature_acts,
+            hidden_pre=hidden_pre,
+            sae_out=torch.zeros_like(x),
+        )
+        losses["l0_loss"].backward()  # type: ignore[union-attr]
+        return sae.W_enc.grad
+
+    # estimator value is 1 / bandwidth = 1.0, and x is all ones
+    on_grad = encoder_grad(ste_to_input=True)
+    assert on_grad is not None
+    assert_close(on_grad, torch.ones(2, 2), atol=1e-6)
+    # Step returns no input gradient at all when the flag is off, so the L0 loss
+    # never reaches the encoder and autograd leaves .grad unset
+    assert encoder_grad(ste_to_input=False) is None

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -629,7 +629,7 @@ def test_JumpReLUTrainingSAE_keeps_threshold_in_float32_across_a_disk_roundtrip(
 def test_JumpReLUTrainingSAE_ste_to_input_routes_the_step_l0_loss_to_the_encoder():
     x = torch.ones(1, 2)
 
-    def encoder_grad(ste_to_input: bool) -> torch.Tensor:
+    def encoder_grad(ste_to_input: bool) -> torch.Tensor | None:
         sae = JumpReLUTrainingSAE(
             build_jumprelu_sae_training_cfg(
                 d_in=2,

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -570,3 +570,41 @@ def test_JumpReLUTrainingSAE_ste_to_input_reaches_the_encoder_for_gated_off_late
     # estimator value is threshold / bandwidth = 1.0, and x is all ones
     assert_close(encoder_grad(ste_to_input=True), torch.ones(2, 2), atol=1e-6)
     assert_close(encoder_grad(ste_to_input=False), torch.zeros(2, 2), atol=1e-6)
+
+
+def test_JumpReLUTrainingSAE_keeps_threshold_in_float32_for_bfloat16_saes():
+    lr, steps, init = 1e-3, 100, 1.1
+    sae = JumpReLUTrainingSAE(
+        build_jumprelu_sae_training_cfg(
+            d_in=16,
+            d_sae=32,
+            dtype="bfloat16",
+            jumprelu_init_threshold=init,
+            jumprelu_bandwidth=2.0,
+            l0_coefficient=1.0,
+        )
+    )
+    assert sae.W_enc.dtype == torch.bfloat16
+    assert sae.threshold.dtype == torch.float32
+
+    optimizer = torch.optim.Adam(sae.parameters(), lr=lr)
+    for _ in range(steps):
+        output = sae.training_forward_pass(
+            step_input=TrainStepInput(
+                sae_in=torch.randn(64, sae.cfg.d_in, dtype=torch.bfloat16),
+                coefficients={"l0": 1.0},
+                dead_neuron_mask=None,
+                n_training_steps=0,
+                is_logging_step=False,
+            )
+        )
+        # the threshold is cast at the use site, so the big tensors stay bfloat16
+        assert output.feature_acts.dtype == torch.bfloat16
+        optimizer.zero_grad()
+        output.loss.backward()
+        optimizer.step()
+
+    # bfloat16 resolves ~0.004 at 1.1, so a bfloat16 threshold would round away
+    # most of the lr-sized steps and barely move
+    moved = abs(sae.threshold.detach().float().mean().item() - init)
+    assert moved > 20 * lr


### PR DESCRIPTION
Two related JumpReLU changes. Both are opt-in or invisible by default.

## 1. `jumprelu_ste_to_input` (default `False`)

Anthropic's [January 2025 update](https://transformer-circuits.pub/2025/january-update/index.html) notes that, unlike Rajamanoharan et al., they *"allow the gradient to flow through straight-through estimator to all model parameters, not just the JumpReLU thresholds"*. SAELens followed DeepMind here: the estimator's gradient reaches only the threshold, and the pre-activations get the hard mask.

Both `JumpReLU` and `Step` depend on `x` only through `(x - threshold)`, so the estimator's gradient wrt `x` is the negation of its gradient wrt `threshold`. The flag adds that term to the input gradient; the threshold gradient is unchanged either way.

## 2. Threshold kept in float32

Adam moves a parameter by at most ~`lr` per step regardless of gradient magnitude, and the JumpReLU threshold sits at O(1). bfloat16 has ~0.4% relative resolution, so a typical update rounds away and the threshold silently stops learning. Over 200 Adam steps at lr 7e-5 from a threshold of 1.1:

| threshold dtype | moved |
|---|---|
| float32 | +0.0123 |
| bfloat16 | +0.0016 |

With `dtype="bfloat16"` today, `jumprelu_init_threshold=1.1` isn't even representable — it stores 1.1016. The threshold is a `d_sae` vector so float32 costs nothing in memory, and it's cast to the compute dtype at each use site, leaving the `(batch, d_sae)` intermediates in the SAE's dtype.

## Evidence

gemma-2-2b layer 12, `d_sae=32768`, 300M tokens, five SAEs sharing one LLM forward pass so every arm sees identical data. Anthropic-style config: tanh sparsity, `bandwidth=2.0`, `l0_coefficient=1.0` warmed over the full run, `normalize_activations="expected_average_only_in"`.

| arm | L0 | dead | MSE | EV |
|---|---|---|---|---|
| ste_off | 21.9 | 0 | 452.85 | 0.7267 |
| ste_on | 30.6 | 0 | 425.65 | 0.7431 |
| ste_on + pre-act loss | 30.7 | 0 | 426.21 | 0.7428 |
| ste_off, bfloat16 params | 83.0 | 111 | 636.12 | 0.6161 |
| ste_on, init threshold 1.1 | 30.7 | 0 | 423.55 | 0.7444 |

**Why the flag defaults to off.** `ste_on` is not a free win: it lands at a *different sparsity point* (L0 30.6 vs 21.9), so its better MSE/EV is not a like-for-like comparison — a sparsity-matched sweep would be needed to claim a Pareto improvement. An earlier gpt2-small run at a very different configuration came out clearly *against* the flag (more dead latents at matched L0, worse MSE). So this is exposed as an option for people following Anthropic's recipe, not as a recommended default.

**What the flag does reliably do is keep gated-off latents reachable.** With `init_threshold=1.1` and the STE off, 98% of latents were dead by step 3.5k and could never recover — a latent below the gate has no gradient path to its encoder. With the STE on, the same threshold converges indistinguishably from `init_threshold=0.1` (L0 30.7 vs 30.6, both 0 dead). It is effectively a revival mechanism, playing a similar role to the pre-act loss.

**bfloat16 parameters remain worse even with the float32 threshold guard** (EV 0.6161 vs 0.7267 against its fp32 twin). The guard prevents the catastrophic freeze; it does not make bf16 params equivalent. `autocast` remains the better route to bf16 compute.

## Notes for reviewers

- Tests: the analytic gradient form at three positions either side of the estimator window for both flag settings; an encoder-gradient test where every latent is gated off, so any `W_enc` gradient can only have arrived via the estimator (exactly `ones` with the flag on, `zeros` with it off); and a bf16 SAE whose threshold still moves under Adam.
- `tests/helpers.py` silently drops config kwargs not in its per-architecture default dict, so new fields must be added there or tests pass vacuously. Bit me while writing these.
- Single run per arm, no seed replication. Earlier matched-step comparisons put run-to-run noise around 1-3%, so the bf16 gap is well outside it, but the `ste_on` vs `ste_off` reconstruction difference deserves a sparsity-matched sweep before anyone reads it as a quality claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)