### PR TITLE
feat(training): add held-out evaluation data

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -489,6 +489,32 @@ For any real training run, you should be logging to Weights and Biases (WandB). 
 
 A number of helpful metrics are logged to WandB, including the sparsity of the SAE, the mean squared error (MSE) of the SAE, dead features, and explained variance. These metrics can be used to monitor the training progress and adjust the training parameters. Below is a screenshot from one training run.
 
+### Held-out evaluation during training
+
+By default, periodic evaluations use the training activation store. To evaluate
+on independent data without consuming or resetting the training stream, set
+`eval_dataset_path`. Use `eval_dataset_split` when the Hugging Face dataset has
+a dedicated validation or test split:
+
+```python
+cfg = LanguageModelSAERunnerConfig(
+    # ... model, hook, SAE, and training options ...
+    dataset_path="your-org/training-data",
+    eval_dataset_path="your-org/training-data",
+    eval_dataset_split="validation",
+)
+```
+
+The runner creates a separate activation store for held-out evaluation and logs
+its reconstruction, sparsity, variance, and model-performance metrics under the
+`held_out/` prefix. It uses the existing `eval_every_n_wandb_logs` cadence.
+Held-out evaluation always generates activations from the evaluation dataset;
+it does not reuse the training activation cache.
+
+Remote dataset code is disabled for held-out evaluation by default. Set
+`eval_dataset_trust_remote_code=True` only when the evaluation dataset requires
+custom loading code and you trust its publisher.
+
 ![screenshot](dashboard_screenshot.png)
 
 ## Best practices for real SAEs

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -138,6 +138,9 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         hook_eval (str): DEPRECATED: Will be removed in v7.0.0. NOT CURRENTLY IN USE. The name of the hook to use for evaluation.
         hook_head_index (int, optional): When the hook is for an activation with a head index, we can specify a specific head to use here.
         dataset_path (str): A Hugging Face dataset path.
+        eval_dataset_path (str, optional): A separate Hugging Face dataset path used only for held-out evaluation. If omitted, evaluation continues to use the training dataset.
+        eval_dataset_split (str): The split to load from `eval_dataset_path`.
+        eval_dataset_trust_remote_code (bool): Whether to trust remote code when loading the held-out evaluation dataset. Defaults to False.
         dataset_trust_remote_code (bool): Whether to trust remote code when loading datasets from Huggingface.
         streaming (bool): Whether to stream the dataset. Streaming large datasets is usually practical.
         is_dataset_tokenized (bool): Whether the dataset is already tokenized.
@@ -296,6 +299,10 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
     sae_lens_training_version: str = field(default_factory=lambda: __version__)
     exclude_special_tokens: bool | list[int] = False
     n_batches_for_norm_estimate: int = 1000  # Default value is 1k, helpful to decrease this if you use a larger batch size
+    # Appended to preserve the positional order of existing config fields.
+    eval_dataset_path: str | None = None
+    eval_dataset_split: str = "train"
+    eval_dataset_trust_remote_code: bool = False
 
     def __post_init__(self):
         if self.hook_eval != "NOT_IN_USE":

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -4,7 +4,7 @@ import signal
 import sys
 from argparse import Namespace
 from collections.abc import Sequence
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import AbstractContextManager, ExitStack
 from dataclasses import dataclass, make_dataclass
 from functools import partial
 from pathlib import Path
@@ -47,6 +47,8 @@ class LLMSaeEvaluator(Generic[T_TRAINING_SAE]):
     eval_batch_size_prompts: int | None
     n_eval_batches: int
     model_kwargs: dict[str, Any]
+    metric_prefix: str = ""
+    pause_data_provider: DataProvider | None = None
 
     def __call__(
         self,
@@ -70,15 +72,20 @@ class LLMSaeEvaluator(Generic[T_TRAINING_SAE]):
             compute_variance_metrics=True,
         )
 
-        # Eval calls into self.activations_store directly, which would race the
-        # prefetcher's producer thread on shared generator state. Pause it for
-        # the duration of the eval.
-        pause_ctx: AbstractContextManager[None] = (
-            data_provider.paused()
-            if isinstance(data_provider, PrefetchingIterator)
-            else nullcontext()
-        )
-        with pause_ctx:
+        # Eval calls into self.activations_store directly. Pause any prefetchers
+        # that could concurrently access evaluation or training model state.
+        pause_contexts: list[AbstractContextManager[None]] = []
+        seen_providers: set[int] = set()
+        for provider in (data_provider, self.pause_data_provider):
+            if (
+                isinstance(provider, PrefetchingIterator)
+                and id(provider) not in seen_providers
+            ):
+                pause_contexts.append(provider.paused())
+                seen_providers.add(id(provider))
+        with ExitStack() as stack:
+            for pause_context in pause_contexts:
+                stack.enter_context(pause_context)
             eval_metrics, _ = run_evals(
                 sae=sae,
                 activation_store=self.activations_store,
@@ -89,17 +96,20 @@ class LLMSaeEvaluator(Generic[T_TRAINING_SAE]):
                 model_kwargs=self.model_kwargs,
             )  # not calculating featurwise metrics here.
 
-        # Remove eval metrics that are already logged during training
-        eval_metrics.pop("metrics/explained_variance", None)
-        eval_metrics.pop("metrics/explained_variance_std", None)
-        eval_metrics.pop("metrics/l0", None)
-        eval_metrics.pop("metrics/l1", None)
-        eval_metrics.pop("metrics/mse", None)
+        if not self.metric_prefix:
+            # Remove eval metrics that are already logged during training.
+            eval_metrics.pop("metrics/explained_variance", None)
+            eval_metrics.pop("metrics/explained_variance_std", None)
+            eval_metrics.pop("metrics/l0", None)
+            eval_metrics.pop("metrics/l1", None)
+            eval_metrics.pop("metrics/mse", None)
 
         # Remove metrics that are not useful for wandb logging
         eval_metrics.pop("metrics/total_tokens_evaluated", None)
 
-        return eval_metrics
+        return {
+            f"{self.metric_prefix}{key}": value for key, value in eval_metrics.items()
+        }
 
 
 class LanguageModelSAETrainingRunner:
@@ -111,6 +121,7 @@ class LanguageModelSAETrainingRunner:
     model: HookedRootModule
     sae: TrainingSAE[Any]
     activations_store: ActivationsStore
+    eval_activations_store: ActivationsStore
     evaluator: "LLMSaeEvaluator[Any]"
 
     def __init__(
@@ -119,6 +130,7 @@ class LanguageModelSAETrainingRunner:
         override_dataset: HfDataset | None = None,
         override_model: HookedRootModule | None = None,
         override_sae: TrainingSAE[Any] | None = None,
+        override_eval_dataset: HfDataset | None = None,
     ):
         if override_dataset is not None:
             logger.warning(
@@ -127,6 +139,10 @@ class LanguageModelSAETrainingRunner:
         if override_model is not None:
             logger.warning(
                 f"You just passed in a model which will override the one specified in your configuration: {cfg.model_name}. As a consequence this run will not be reproducible via configuration alone."
+            )
+        if override_eval_dataset is not None:
+            logger.warning(
+                f"You just passed in an evaluation dataset which will override the one specified in your configuration: {cfg.eval_dataset_path}. As a consequence this run will not be reproducible via configuration alone."
             )
 
         self.cfg = cfg
@@ -157,6 +173,27 @@ class LanguageModelSAETrainingRunner:
             override_dataset=override_dataset,
         )
 
+        has_held_out_dataset = (
+            override_eval_dataset is not None or self.cfg.eval_dataset_path is not None
+        )
+        if has_held_out_dataset:
+            eval_dataset = (
+                override_eval_dataset
+                if override_eval_dataset is not None
+                else self.cfg.eval_dataset_path
+            )
+            assert eval_dataset is not None
+            self.eval_activations_store = ActivationsStore.from_config(
+                self.model,
+                self.cfg,
+                override_dataset=eval_dataset,
+                dataset_split=self.cfg.eval_dataset_split,
+                use_cached_activations=False,
+                dataset_trust_remote_code=self.cfg.eval_dataset_trust_remote_code,
+            )
+        else:
+            self.eval_activations_store = self.activations_store
+
         if override_sae is None:
             if self.cfg.from_pretrained_path is not None:
                 self.sae = TrainingSAE.load_from_disk(
@@ -175,10 +212,11 @@ class LanguageModelSAETrainingRunner:
 
         self.evaluator = LLMSaeEvaluator(
             model=self.model,
-            activations_store=self.activations_store,
+            activations_store=self.eval_activations_store,
             eval_batch_size_prompts=self.cfg.eval_batch_size_prompts,
             n_eval_batches=self.cfg.n_eval_batches,
             model_kwargs=self.cfg.model_kwargs,
+            metric_prefix="held_out/" if has_held_out_dataset else "",
         )
 
     def run(self):
@@ -207,9 +245,15 @@ class LanguageModelSAETrainingRunner:
                 iter(self.activations_store), prefetch=prefetch_size
             )
 
+        eval_data_provider: DataProvider = self.eval_activations_store
+        if self.eval_activations_store is self.activations_store:
+            eval_data_provider = data_provider
+        self.evaluator.pause_data_provider = data_provider
+
         trainer = SAETrainer(
             sae=self.sae,
             data_provider=data_provider,
+            eval_data_provider=eval_data_provider,
             evaluator=self.evaluator,
             save_checkpoint_fn=self.save_checkpoint,
             cfg=self.cfg.to_sae_trainer_config(),

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -117,17 +117,21 @@ class ActivationsStore:
         model: HookedRootModule,
         cfg: LanguageModelSAERunnerConfig[T_TRAINING_SAE_CONFIG]
         | CacheActivationsRunnerConfig,
-        override_dataset: HfDataset | None = None,
+        override_dataset: HfDataset | str | None = None,
+        dataset_split: str = "train",
+        use_cached_activations: bool | None = None,
+        dataset_trust_remote_code: bool | None = None,
     ) -> ActivationsStore:
         if isinstance(cfg, CacheActivationsRunnerConfig):
             return cls.from_cache_activations(model, cfg)
 
         cached_activations_path = cfg.cached_activations_path
+        if use_cached_activations is None:
+            use_cached_activations = cfg.use_cached_activations
+        if dataset_trust_remote_code is None:
+            dataset_trust_remote_code = cfg.dataset_trust_remote_code
         # set cached_activations_path to None if we're not using cached activations
-        if (
-            isinstance(cfg, LanguageModelSAERunnerConfig)
-            and not cfg.use_cached_activations
-        ):
+        if isinstance(cfg, LanguageModelSAERunnerConfig) and not use_cached_activations:
             cached_activations_path = None
 
         if override_dataset is None and cfg.dataset_path == "":
@@ -148,7 +152,9 @@ class ActivationsStore:
             )
         return cls(
             model=model,
-            dataset=override_dataset or cfg.dataset_path,
+            dataset=override_dataset
+            if override_dataset is not None
+            else cfg.dataset_path,
             streaming=cfg.streaming,
             hook_name=cfg.hook_name,
             hook_head_index=cfg.hook_head_index,
@@ -167,7 +173,8 @@ class ActivationsStore:
             cached_activations_path=cached_activations_path,
             model_kwargs=cfg.model_kwargs,
             autocast_lm=cfg.autocast_lm,
-            dataset_trust_remote_code=cfg.dataset_trust_remote_code,
+            dataset_trust_remote_code=dataset_trust_remote_code,
+            dataset_split=dataset_split,
             seqpos_slice=cfg.seqpos_slice,
             exclude_special_tokens=exclude_special_tokens,
             disable_concat_sequences=cfg.disable_concat_sequences,
@@ -334,6 +341,7 @@ class ActivationsStore:
         sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = "bos",
         activations_mixing_fraction: float = 0.5,
         use_chat_formatting: bool = False,
+        dataset_split: str = "train",
     ):
         self.model = model
         if model_kwargs is None:
@@ -342,7 +350,7 @@ class ActivationsStore:
         self.dataset = (
             load_dataset(
                 dataset,
-                split="train",
+                split=dataset_split,
                 streaming=streaming,  # type: ignore
                 trust_remote_code=dataset_trust_remote_code,  # type: ignore
             )

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -60,6 +60,7 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
     """
 
     data_provider: DataProvider
+    eval_data_provider: DataProvider
     activation_scaler: ActivationScaler
     evaluator: Evaluator[T_TRAINING_SAE] | None
     coefficient_schedulers: dict[str, CoefficientScheduler]
@@ -71,9 +72,13 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
         data_provider: DataProvider,
         evaluator: Evaluator[T_TRAINING_SAE] | None = None,
         save_checkpoint_fn: SaveCheckpointFn | None = None,
+        eval_data_provider: DataProvider | None = None,
     ) -> None:
         self.sae = sae
         self.data_provider = data_provider
+        self.eval_data_provider = (
+            data_provider if eval_data_provider is None else eval_data_provider
+        )
         self.evaluator = evaluator
         self.activation_scaler = ActivationScaler()
         self.save_checkpoint_fn = save_checkpoint_fn
@@ -448,7 +453,9 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
         ) == 0:
             self.sae.eval()
             eval_metrics = (
-                self.evaluator(self.sae, self.data_provider, self.activation_scaler)
+                self.evaluator(
+                    self.sae, self.eval_data_provider, self.activation_scaler
+                )
                 if self.evaluator is not None
                 else {}
             )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -65,6 +65,9 @@ class LanguageModelSAERunnerConfigDict(TypedDict, total=False):
     hook_name: str
     hook_head_index: int | None
     dataset_path: str
+    eval_dataset_path: str | None
+    eval_dataset_split: str
+    eval_dataset_trust_remote_code: bool
     dataset_trust_remote_code: bool
     streaming: bool
     is_dataset_tokenized: bool
@@ -173,6 +176,9 @@ def _get_default_runner_config() -> LanguageModelSAERunnerConfigDict:
         "hook_name": "blocks.0.hook_mlp_out",
         "hook_head_index": None,
         "dataset_path": NEEL_NANDA_C4_10K_DATASET,
+        "eval_dataset_path": None,
+        "eval_dataset_split": "train",
+        "eval_dataset_trust_remote_code": False,
         "streaming": False,
         "dataset_trust_remote_code": True,
         "is_dataset_tokenized": False,

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -1,11 +1,15 @@
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import torch
+from datasets import Dataset
 from safetensors.torch import load_file
-from transformer_lens import HookedTransformer
+from transformer_lens import HookedTransformer, HookedTransformerConfig
 
 from sae_lens import __version__
 from sae_lens.config import LanguageModelSAERunnerConfig
@@ -33,7 +37,21 @@ from tests.helpers import (
     TINYSTORIES_MODEL,
     assert_close,
     build_runner_cfg_for_arch,
+    random_params,
 )
+
+
+class _PausableDataProvider(Iterator[torch.Tensor]):
+    def __init__(self) -> None:
+        self.paused_calls = 0
+
+    def __next__(self) -> torch.Tensor:
+        return torch.empty(0)
+
+    @contextmanager
+    def paused(self) -> Iterator[None]:
+        self.paused_calls += 1
+        yield
 
 
 @pytest.mark.parametrize("architecture", ALL_TRAINING_ARCHITECTURES)
@@ -151,6 +169,99 @@ def test_LanguageModelSAETrainingRunner_runs_with_prefetch_llm_batches(
     runner = LanguageModelSAETrainingRunner(cfg, override_model=ts_model)
     sae = runner.run()
     assert sae.cfg.architecture() == "standard"
+
+
+def test_language_model_runner_builds_held_out_evaluation_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded_splits: list[tuple[str, str, bool]] = []
+    eval_dataset = Dataset.from_list([{"text": "held out example"}] * 20)
+
+    def load_eval_dataset(
+        path: str,
+        *,
+        split: str,
+        streaming: bool,
+        trust_remote_code: bool,
+    ) -> Dataset:
+        del streaming
+        loaded_splits.append((path, split, trust_remote_code))
+        return eval_dataset
+
+    monkeypatch.setattr(
+        "sae_lens.training.activations_store.load_dataset", load_eval_dataset
+    )
+    cfg = build_runner_cfg_for_arch(
+        architecture="standard",
+        eval_dataset_path="test/held-out",
+        eval_dataset_split="validation",
+        context_size=4,
+        logger={"wandb_id": "held-out-runner-test"},
+    )
+    train_dataset = Dataset.from_list([{"text": "training example"}] * 20)
+    model = MagicMock()
+
+    runner = LanguageModelSAETrainingRunner(
+        cfg,
+        override_dataset=train_dataset,
+        override_model=model,
+    )
+
+    assert loaded_splits == [("test/held-out", "validation", False)]
+    assert runner.eval_activations_store is not runner.activations_store
+    assert runner.evaluator.activations_store is runner.eval_activations_store
+    assert runner.evaluator.metric_prefix == "held_out/"
+
+
+def test_runner_evaluates_held_out_data_without_consuming_training_data() -> None:
+    model = HookedTransformer(
+        HookedTransformerConfig(
+            n_layers=1,
+            d_model=16,
+            d_head=8,
+            n_heads=2,
+            d_mlp=32,
+            d_vocab=32,
+            n_ctx=4,
+            act_fn="relu",
+            device="cpu",
+        )
+    )
+    first_train_tokens = [1, 2, 3, 4]
+    train_dataset = Dataset.from_list(
+        [{"tokens": first_train_tokens}] + [{"tokens": [9, 9, 9, 9]}] * 19
+    )
+    eval_dataset = Dataset.from_list([{"tokens": [5, 6, 7, 8]}] * 20)
+    cfg = build_runner_cfg_for_arch(
+        architecture="standard",
+        d_in=16,
+        d_sae=32,
+        context_size=4,
+        training_tokens=20,
+        n_batches_in_buffer=2,
+        store_batch_size_prompts=2,
+        train_batch_size_tokens=4,
+        eval_batch_size_prompts=2,
+        n_eval_batches=1,
+        logger={"wandb_id": "held-out-integration-test"},
+    )
+    runner = LanguageModelSAETrainingRunner(
+        cfg,
+        override_dataset=train_dataset,
+        override_model=model,
+        override_eval_dataset=eval_dataset,
+    )
+    random_params(runner.sae)
+
+    metrics = runner.evaluator(
+        runner.sae,
+        runner.eval_activations_store,
+        ActivationScaler(),
+    )
+
+    assert metrics
+    assert all(key.startswith("held_out/") for key in metrics)
+    assert runner.activations_store.get_batch_tokens(1).tolist() == [first_train_tokens]
 
 
 class _CompiledCallable:
@@ -519,6 +630,81 @@ class TestLLMSaeEvaluator:
 
         for metric_key in filtered_metrics:
             assert metric_key not in metrics
+
+    def test_llm_sae_evaluator_prefixes_held_out_metrics(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def run_evals_stub(**kwargs: Any) -> tuple[dict[str, Any], None]:
+            del kwargs
+            return {
+                "metrics/l0": 2.0,
+                "metrics/l1": 3.0,
+                "metrics/mse": 1.0,
+            }, None
+
+        monkeypatch.setattr(
+            "sae_lens.llm_sae_training_runner.run_evals", run_evals_stub
+        )
+        activation_store = MagicMock()
+        activation_store.exclude_special_tokens = None
+        evaluator = LLMSaeEvaluator(
+            model=MagicMock(),
+            activations_store=activation_store,
+            eval_batch_size_prompts=2,
+            n_eval_batches=1,
+            model_kwargs={},
+            metric_prefix="held_out/",
+        )
+
+        metrics = evaluator(
+            sae=MagicMock(),
+            data_provider=activation_store,
+            activation_scaler=ActivationScaler(),
+        )
+
+        assert metrics
+        assert metrics["held_out/metrics/l0"] == 2.0
+        assert metrics["held_out/metrics/l1"] == 3.0
+        assert metrics["held_out/metrics/mse"] == 1.0
+        assert all(key.startswith("held_out/") for key in metrics)
+
+    def test_llm_sae_evaluator_pauses_training_and_eval_prefetchers(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def run_evals_stub(**kwargs: Any) -> tuple[dict[str, Any], None]:
+            del kwargs
+            return {}, None
+
+        monkeypatch.setattr(
+            "sae_lens.llm_sae_training_runner.run_evals", run_evals_stub
+        )
+        monkeypatch.setattr(
+            "sae_lens.llm_sae_training_runner.PrefetchingIterator",
+            _PausableDataProvider,
+        )
+        activation_store = MagicMock()
+        activation_store.exclude_special_tokens = None
+        eval_provider = _PausableDataProvider()
+        training_provider = _PausableDataProvider()
+        evaluator = LLMSaeEvaluator(
+            model=MagicMock(),
+            activations_store=activation_store,
+            eval_batch_size_prompts=2,
+            n_eval_batches=1,
+            model_kwargs={},
+            pause_data_provider=training_provider,
+        )
+
+        evaluator(
+            sae=MagicMock(),
+            data_provider=eval_provider,
+            activation_scaler=ActivationScaler(),
+        )
+
+        assert eval_provider.paused_calls == 1
+        assert training_provider.paused_calls == 1
 
     def test_llm_sae_evaluator_handles_ignore_tokens_with_exclude_special_tokens(
         self,

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -196,6 +196,9 @@ def test_LanguageModelSAERunnerConfig_to_dict_and_from_dict():
         ),
         seqpos_slice=(0, 10),
         context_size=10,
+        eval_dataset_path="test/held-out",
+        eval_dataset_split="validation",
+        eval_dataset_trust_remote_code=True,
     )
     cfg_dict = cfg.to_dict()
     assert cfg_dict == cfg.to_dict()

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -4,6 +4,7 @@ from typing import Any, Callable
 
 import pytest
 import torch
+import wandb
 from datasets import Dataset
 from transformer_lens import HookedTransformer
 from typing_extensions import override
@@ -35,6 +36,7 @@ from tests.helpers import (
     build_runner_cfg,
     build_sae_training_cfg,
     load_model_cached,
+    random_params,
 )
 
 
@@ -83,6 +85,69 @@ def trainer(  # type: ignore
         data_provider=activation_store,
         evaluator=evaluator,
     )
+
+
+def test_sae_trainer_uses_independent_eval_data_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    d_in = 8
+    train_batch = torch.ones(4, d_in)
+    eval_batch = torch.full((4, d_in), 7.0)
+    train_data_provider = iter([train_batch])
+    eval_data_provider = iter([eval_batch])
+    evaluated_batches: list[torch.Tensor] = []
+
+    def evaluator(
+        sae: StandardTrainingSAE,
+        data_provider: Any,
+        activation_scaler: Any,
+    ) -> dict[str, Any]:
+        del sae, activation_scaler
+        evaluated_batches.append(next(data_provider))
+        return {}
+
+    cfg = build_runner_cfg(
+        d_in=d_in, d_sae=16, logger={"wandb_id": "held-out-eval-test"}
+    )
+    sae = StandardTrainingSAE(cfg.sae)
+    random_params(sae)
+    trainer = SAETrainer(
+        cfg=cfg.to_sae_trainer_config(),
+        sae=sae,
+        data_provider=train_data_provider,
+        eval_data_provider=eval_data_provider,
+        evaluator=evaluator,
+    )
+
+    def ignore_wandb_log(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+
+    monkeypatch.setattr(wandb, "log", ignore_wandb_log)
+
+    trainer.n_training_steps = (
+        cfg.logger.wandb_log_frequency * cfg.logger.eval_every_n_wandb_logs - 1
+    )
+    trainer._run_and_log_evals()
+
+    assert_close(evaluated_batches[0], eval_batch)
+    assert_close(next(train_data_provider), train_batch)
+
+
+def test_sae_trainer_defaults_to_training_data_for_evaluation() -> None:
+    data_provider = iter([torch.ones(4, 8)])
+    cfg = build_runner_cfg(
+        d_in=8, d_sae=16, logger={"wandb_id": "held-out-eval-default-test"}
+    )
+
+    sae = StandardTrainingSAE(cfg.sae)
+    random_params(sae)
+    trainer = SAETrainer(
+        cfg=cfg.to_sae_trainer_config(),
+        sae=sae,
+        data_provider=data_provider,
+    )
+
+    assert trainer.eval_data_provider is data_provider
 
 
 def modify_sae_output(


### PR DESCRIPTION
# Description

Adds opt-in held-out evaluation during SAE training. A run can evaluate periodically on a separate Hugging Face dataset and split without consuming, resetting, or reusing the training data stream.

Fixes #446.

## Motivation

`LLMSaeEvaluator` previously reused the training `ActivationsStore`. This coupled evaluation to training iterator state and made it impossible to distinguish genuinely held-out metrics from metrics computed on training data.

This PR introduces an independent evaluation data path while preserving existing behavior for configurations that do not opt in.

## What changed

### Configuration

Adds three optional `LanguageModelSAERunnerConfig` fields:

- `eval_dataset_path: str | None = None`
- `eval_dataset_split: str = "train"`
- `eval_dataset_trust_remote_code: bool = False`

The fields are appended to preserve the positional order of existing configuration fields.

### Independent evaluation data

When `eval_dataset_path` or `override_eval_dataset` is provided, `LanguageModelSAETrainingRunner` creates a separate `ActivationsStore` for evaluation.

The held-out store:

- has independent dataset and iterator state;
- never consumes or resets the training store;
- does not reuse the training activation cache;
- loads the requested evaluation split; and
- disables remote dataset code by default.

When no held-out dataset is configured, evaluation continues to use the training provider exactly as before.

### Metrics

Held-out evaluation metrics are logged under the `held_out/` prefix. L0, L1, MSE, reconstruction, explained-variance, and model-performance metrics are retained rather than filtered as duplicate training metrics.

### Prefetch safety

Evaluation pauses distinct training and evaluation prefetch providers when required. This prevents a background training producer from using shared model state concurrently with evaluation.

### Documentation

`docs/training_saes.md` documents configuration, metric namespacing, evaluation cadence, cache isolation, and remote-code trust behavior.

## Backward compatibility

- The feature is opt-in.
- Existing configurations retain training-provider evaluation.
- Existing constructor positional argument order is preserved.
- No SAE state-dict or serialized parameter format changes.
- No dependency is added.

## Security

A separate evaluation dataset does not inherit the training dataset's remote-code trust implicitly. `eval_dataset_trust_remote_code` defaults to `False` and must be enabled explicitly for a trusted dataset that requires custom loading code.

## Performance

The default path has no additional data store or evaluation work.

When enabled, one additional dataset/store object is retained and evaluation performs model forwards at the existing `eval_every_n_wandb_logs` cadence. Training-step computation is unchanged outside evaluation windows.

## Testing

Added functional coverage for:

- selecting a distinct evaluation provider in `SAETrainer`;
- preserving the existing training-provider fallback;
- loading the requested evaluation split;
- disabling remote evaluation dataset code by default;
- retaining and prefixing held-out L0, L1, and MSE metrics;
- pausing separate training and evaluation prefetch providers;
- round-tripping non-default evaluation configuration;
- running evaluation with a real CPU `HookedTransformer` and distinct tokenized datasets; and
- proving held-out evaluation leaves training data at its first batch.

Local validation performed:

- repository pre-commit hooks;
- Ruff formatting and lint;
- Pyright;
- focused feature tests; and
- a full-suite run, with two unrelated local Kaleido/Chrome rendering failures.

The focused run also reports existing TransformerLens deprecations and activation-store dataset warnings. The new real-model integration test exercises one deprecated `HookedTransformer` compatibility path and exposes the existing tensor-copy warning; neither is treated as a failure or hidden by warning filters.

Upstream CI is requested through this draft PR and should be treated as authoritative for the complete supported environment.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] This change requires a documentation update

# Checklist

- [x] I have commented code in hard-to-understand areas
- [x] I have made corresponding documentation changes
- [ ] My changes generate no warnings
- [x] I have added tests that prove the feature works
- [ ] The entire test suite passes locally without environment-specific exceptions
- [x] I have not rewritten tests relating to key interfaces in a way that affects backward compatibility

### Formatting, typing, and tests

- [x] Ruff, Pyright, pre-commit, and focused tests pass locally
- [ ] Upstream CI passes

### Performance check

- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

These training-quality checks are intentionally unchecked because this PR changes evaluation data plumbing, not the SAE training objective. It makes no claim about training-quality improvements.

## Reviewer questions

1. Are `eval_dataset_path` and `eval_dataset_split` the preferred configuration names?
2. Is `held_out/` the preferred metric namespace?
3. Should held-out activation-cache support remain a future extension, with the first version always generating evaluation activations from the held-out dataset?
