### PR TITLE
fix: load trainer state onto the configured device

### DIFF
--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -314,7 +314,9 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
     def load_trainer_state(self, checkpoint_path: Path | str) -> None:
         checkpoint_path = Path(checkpoint_path)
         self.activation_scaler.load(checkpoint_path / ACTIVATION_SCALER_CFG_FILENAME)
-        state_dict = torch.load(checkpoint_path / TRAINER_STATE_FILENAME)
+        state_dict = torch.load(
+            checkpoint_path / TRAINER_STATE_FILENAME, map_location=self.cfg.device
+        )
         self.optimizer.load_state_dict(state_dict["optimizer"])
         self.lr_scheduler.load_state_dict(state_dict["lr_scheduler"])
         self.n_training_samples = state_dict["n_training_samples"]

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from typing import Any, Callable
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -718,6 +719,63 @@ def test_SAETrainer_save_and_load_from_checkpoint(
             assert torch.allclose(old_state[key], new_state[key])
         else:
             assert old_state[key] == new_state[key]
+
+
+def _build_trainer_for_checkpointing(
+    ts_model: HookedTransformer, checkpoint_dir: Path
+) -> SAETrainer[StandardTrainingSAE, StandardTrainingSAEConfig]:
+    cfg = build_runner_cfg(checkpoint_path=str(checkpoint_dir), context_size=8)
+    activation_store = ActivationsStore.from_config(
+        ts_model,
+        cfg,
+        override_dataset=Dataset.from_list([{"text": "hello world"}] * 100),
+    )
+    return SAETrainer(
+        cfg=cfg.to_sae_trainer_config(),
+        sae=TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict()),
+        data_provider=activation_store,
+    )
+
+
+def test_load_trainer_state_reads_the_checkpoint_onto_the_configured_device(
+    ts_model: HookedTransformer,
+    tmp_path: Path,
+) -> None:
+    checkpoint_dir = tmp_path / "checkpoints"
+    trainer = _build_trainer_for_checkpointing(ts_model, checkpoint_dir)
+    trainer.save_trainer_state(checkpoint_dir)
+
+    new_trainer = _build_trainer_for_checkpointing(ts_model, checkpoint_dir)
+    with patch.object(torch, "load", wraps=torch.load) as load_spy:
+        new_trainer.load_trainer_state(checkpoint_dir)
+
+    assert load_spy.call_args is not None
+    assert load_spy.call_args.kwargs.get("map_location") == new_trainer.cfg.device
+
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.backends.mps.is_available()),
+    reason="Needs a second device to write the checkpoint from.",
+)
+def test_load_trainer_state_moves_an_accelerator_checkpoint_onto_cpu(
+    ts_model: HookedTransformer,
+    tmp_path: Path,
+) -> None:
+    accelerator = "cuda:0" if torch.cuda.is_available() else "mps"
+    checkpoint_dir = tmp_path / "checkpoints"
+
+    trainer = _build_trainer_for_checkpointing(ts_model, checkpoint_dir)
+    trainer.act_freq_scores = torch.tensor([1.0, 2.0, 3.0], device=accelerator)
+    trainer.n_forward_passes_since_fired = torch.tensor(
+        [1.0, 2.0, 3.0], device=accelerator
+    )
+    trainer.save_trainer_state(checkpoint_dir)
+
+    new_trainer = _build_trainer_for_checkpointing(ts_model, checkpoint_dir)
+    new_trainer.load_trainer_state(checkpoint_dir)
+
+    assert new_trainer.act_freq_scores.device.type == "cpu"
+    assert new_trainer.n_forward_passes_since_fired.device.type == "cpu"
 
 
 def test_sae_trainer_fit_logs_train_eval_and_sparsity_metrics_to_wandb(

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -732,7 +732,7 @@ def _build_trainer_for_checkpointing(
     )
     return SAETrainer(
         cfg=cfg.to_sae_trainer_config(),
-        sae=TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict()),
+        sae=StandardTrainingSAE.from_dict(cfg.get_training_sae_cfg_dict()),
         data_provider=activation_store,
     )
 


### PR DESCRIPTION
# Description

`SAETrainer.load_trainer_state` calls `torch.load` without `map_location`, so the restored tensors come back on whatever device the checkpoint was written from instead of the device the trainer is configured for.

`act_freq_scores` and `n_forward_passes_since_fired` are created on `cfg.device` in `__init__` and reset on `cfg.device` in `_reset_running_sparsity_stats`, so only the restore path disagrees with the rest of the class. Every other `torch.load` in the codebase already passes `map_location`, which is the five call sites in `pretrained_sae_loaders.py`, and this is the only one that does not.

It is reachable through the ordinary resume path, since `LanguageModelSAETrainingRunner` calls `load_trainer_state` for `resume_from_checkpoint` and `MultiSAETrainer` calls it per SAE. Resuming a run on a different device from the one it was trained on then fails on the first sparsity accumulation in `_train_step`:

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
```

Resuming a CUDA checkpoint on a machine without CUDA is worse, since it raises inside `torch.load` before any state is restored.

The fix passes the trainer's own configured device:

```python
state_dict = torch.load(
    checkpoint_path / TRAINER_STATE_FILENAME, map_location=self.cfg.device
)
```

Nothing changes when a checkpoint is saved and resumed on the same device, which is why the existing round-trip test did not catch it, since it builds both trainers on the default device.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

Two tests, both failing on current `main`:

- `test_load_trainer_state_reads_the_checkpoint_onto_the_configured_device` asserts `torch.load` receives `map_location`, and runs everywhere including CPU-only CI. On `main` it fails as `assert None == 'cpu'`.
- `test_load_trainer_state_moves_an_accelerator_checkpoint_onto_cpu` writes the checkpoint from an accelerator and resumes on CPU. It is skipped without a second device, following the GPU-gated tests in `test_activations_store.py`. On `main` it fails as `assert 'mps' == 'cpu'`.

Reverting the one-line change while keeping both tests fails both. The full `tests/training/test_sae_trainer.py` passes at 24 passed and 1 skipped, where the skip is the pre-existing fp16 case.

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting.

`ruff check` and `ruff format --check` are clean. `pyright` reports three more instances of `Type of parameter "ts_model" is unknown`, the same pre-existing report the other `ts_model` tests in that file already produce, since the fixture is untyped.

### Performance Check.

Not applicable. This only changes which device the running-sparsity tensors are restored onto when resuming, so L0, CE loss, MSE loss and feature dashboards are unaffected.
